### PR TITLE
MCOL-990 Add resetRow method

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,11 +1,16 @@
 Version History
 ===============
 
-+---------+-----------------------------------------------------------------------+
-| Version | Changes                                                               |
-+=========+=======================================================================+
-| 1.1.1   | - Add :cpp:func:`ColumnStoreBulkInsert::isActive`                     |
-|         | - Make :cpp:func:`ColumnStoreBulkInsert::rollback` fail without error |
-+---------+-----------------------------------------------------------------------+
-| 1.1.0β  | - First beta release                                                  |
-+---------+-----------------------------------------------------------------------+
+This is a version history of C++ API interface changes. It does not include internal fixes and changes.
+
++---------+----------------------------------------------------------------------------------------------+
+| Version | Changes                                                                                      |
++=========+==============================================================================================+
+| 1.1.1   | - Add :cpp:func:`ColumnStoreBulkInsert::isActive`                                            |
+|         | - Make :cpp:func:`ColumnStoreBulkInsert::rollback` fail without error                        |
+|         | - Add :cpp:func:`ColumnStoreBulkInsert::resetRow`                                            |
+|         | - :cpp:func:`ColumnStoreDateTime::ColumnStoreDateTime` now uses uint32_t for every parameter |
+|         | - :cpp:class:`ColumnStoreSystemCatalog` now uses const for the sub-class strings             |
++---------+----------------------------------------------------------------------------------------------+
+| 1.1.0β  | - First beta release                                                                         |
++---------+----------------------------------------------------------------------------------------------+

--- a/docs/reference/bulk_insert.rst
+++ b/docs/reference/bulk_insert.rst
@@ -155,6 +155,15 @@ This example can be used inside the try...catch blocks in the :cpp:class:`Column
    bulkInsert->setNull(0)->setNull(1)->setNull(2)->setNull(3)->writeRow();
    ...
 
+resetRow()
+----------
+
+.. cpp:function:: ColumnStoreBulkInsert* ColumnStoreBulkInsert::resetRow()
+
+   Resets everything that has been set for the current row. This method should be used to clear the row memory without using :cpp:func:`ColumnStoreBulkInsert::writeRow`.
+
+   :raises ColumnStoreUsageError: If the transaction has already been closed
+
 writeRow()
 ----------
 

--- a/docs/reference/types.rst
+++ b/docs/reference/types.rst
@@ -158,6 +158,22 @@ ColumnStoreDateTime()
    :param format: The format specifier for the date/time string. This uses the `strptime format <http://pubs.opengroup.org/onlinepubs/9699919799/functions/strptime.html>`_.
    :raises ColumnStoreDataError: When an invalid date or time is supplied
 
+.. cpp:function:: ColumnStoreDateTime::ColumnStoreDateTime(uint32_t year, uint32_t month, uint32_t day, uint32_t hour, uint32_t minute, uint32_t second, uint32_t microsecond)
+
+   Sets the date/time based on a given set of intergers
+
+   .. note::
+      Microseconds are for future usage, they are not currently supported in ColumnStore.
+
+   :param year: The year
+   :param month: The month of year
+   :param day: The day of month
+   :param hour: The hour
+   :param minute: The minute
+   :param second: The second
+   :param microsecond: The microseconds
+   :raises ColumnStoreDataError: When an invalid date or time is supplied
+
 set()
 -----
 
@@ -286,7 +302,7 @@ ColumnStoreSystemCatalogTable Class
 getSchemaName()
 ---------------
 
-.. cpp:function:: std::string& ColumnStoreSystemCatalogTable::getSchemaName()
+.. cpp:function:: const std::string& ColumnStoreSystemCatalogTable::getSchemaName()
 
    Retrieves the database schema name for the table
 
@@ -295,7 +311,7 @@ getSchemaName()
 getTableName()
 --------------
 
-.. cpp:function:: std::string& ColumnStoreSystemCatalogTable::getTableName()
+.. cpp:function:: const std::string& ColumnStoreSystemCatalogTable::getTableName()
 
    Retrieves the table name for the table
 
@@ -358,7 +374,7 @@ getOID()
 getColumnName()
 ---------------
 
-.. cpp:function:: std::string& ColumnStoreSystemCatalogColumn::getColumnName()
+.. cpp:function:: const std::string& ColumnStoreSystemCatalogColumn::getColumnName()
 
    Retrieves the name of the column
 
@@ -403,7 +419,7 @@ getPosition()
 getDefaultValue()
 -----------------
 
-.. cpp:function:: std::string& ColumnStoreSystemCatalogColumn::getDefaultValue()
+.. cpp:function:: const std::string& ColumnStoreSystemCatalogColumn::getDefaultValue()
 
    Retrieves the default value for the column in text. The value is empty for no default.
 

--- a/libmcsapi/mcsapi_bulk.h
+++ b/libmcsapi/mcsapi_bulk.h
@@ -75,6 +75,7 @@ public:
     ColumnStoreBulkInsert* setColumn(uint16_t columnNumber, ColumnStoreDecimal& value, columnstore_data_convert_status_t* status = nullptr);
     ColumnStoreBulkInsert* setNull(uint16_t columnNumber, columnstore_data_convert_status_t* status = nullptr);
     ColumnStoreBulkInsert* writeRow();
+    ColumnStoreBulkInsert* resetRow();
     void commit();
     void rollback();
     ColumnStoreSummary& getSummary();

--- a/src/mcsapi_bulk.cpp
+++ b/src/mcsapi_bulk.cpp
@@ -224,6 +224,17 @@ ColumnStoreBulkInsert* ColumnStoreBulkInsert::setNull(uint16_t columnNumber, col
     return this;
 }
 
+ColumnStoreBulkInsert* ColumnStoreBulkInsert::resetRow()
+{
+    if (mImpl->transactionClosed)
+    {
+        std::string errmsg = "Bulk insert has been committed or rolled back and cannot be reused";
+        throw ColumnStoreUsageError(errmsg);
+    }
+    mImpl->row->clear();
+    return this;
+}
+
 ColumnStoreBulkInsert* ColumnStoreBulkInsert::writeRow()
 {
     if (mImpl->transactionClosed)

--- a/test/bad-usage.cpp
+++ b/test/bad-usage.cpp
@@ -185,6 +185,24 @@ TEST(BadUsage, SecondCommit)
     delete driver;
 }
 
+/* Test that write after reset fails */
+TEST(BadUsage, WriteAfterReset)
+{
+    std::string table("badusage");
+    std::string db("mcsapi");
+    mcsapi::ColumnStoreDriver* driver;
+    mcsapi::ColumnStoreBulkInsert* bulk;
+    driver = new mcsapi::ColumnStoreDriver();
+    bulk = driver->createBulkInsert(db, table, 0, 0);
+    bulk->setColumn(0, (uint32_t)1);
+    bulk->setColumn(1, (uint32_t)1000);
+    bulk->resetRow();
+    ASSERT_THROW(bulk->writeRow(), mcsapi::ColumnStoreUsageError);
+    delete bulk;
+    delete driver;
+}
+
+
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/version.h
+++ b/version.h
@@ -1,4 +1,0 @@
-#pragma once
-
-#define GIT_VERSION "1.1.0-1ae18f5"
-#define GIT_VERSION_SHORT "1.1.1"


### PR DESCRIPTION
Add a resetRow method to clear the current set rows without writing
them.

Additionally this change fixes documentation issues and removes a file
that was accidentally committed.