### PR TITLE
Allow out-of-source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ if (NOT SNAPPY_FOUND)
 endif()
 
 include_directories(${CMAKE_SOURCE_DIR})
+include_directories(${CMAKE_BINARY_DIR})
 
 OPTION(RUN_CPPCHECK "Run cppcheck" OFF)
 


### PR DESCRIPTION
Including the binary directory allows the source and binary directories to be in different places.