### PR TITLE
Fix Debian 8 build failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,17 @@ if(NOT COMPILER_SUPPORTS_CXX11)
     message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
 endif()
 
+CHECK_CXX_SOURCE_COMPILES("
+#include <time.h>
+#include <sstream>
+#include <iomanip>
+int main(int argc, char** argv){
+    tm time = {};
+    std::istringstream ss(\"01-01-01 00:00:00\");
+    ss >> std::get_time(&time, \"%Y\");
+    return 0;
+}" HAVE_GET_TIME)
+
 include(cmake/version.cmake)
 
 # use, i.e. don't skip the full RPATH for the build tree

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ sudo mv libg* /usr/lib/
 ```
 ### Debian 8 (Jessie)
 
-Debian Jessie will only compile if the latest CLang is along with LLVM's libc++, it also requires packages that are not in the main repositories. First of all you need Debian's Jessie backports repository enabled, edit the file `/etc/apt/sources.list` and add the following line:
+Debian Jessie requires packages that are not in the main repositories. First of all you need Debian's Jessie backports repository enabled, edit the file `/etc/apt/sources.list` and add the following line:
 
 ```
 deb http://httpredir.debian.org/debian jessie-backports main contrib non-free
@@ -47,15 +47,7 @@ deb http://httpredir.debian.org/debian jessie-backports main contrib non-free
 Then install the following:
 
 ```shell
-sudo apt-get install cmake g++ libuv1-dev libxml2-dev libsnappy-dev pkg-config clang-3.8 libc++-dev swig python-dev default-jdk
-```
-
-Now set the following environment variables so that CLang is used to compile:
-
-```shell
-export CC=clang-3.8
-export CXX=clang++-3.8
-export CXXFLAGS=-stdlib=libc++
+sudo apt-get install cmake g++ libuv1-dev libxml2-dev libsnappy-dev pkg-config libc++-dev swig python-dev default-jdk
 ```
 
 For the documentation:
@@ -65,7 +57,7 @@ sudo apt-get install python-sphinx texlive-latex-recommended texlive-latex-extra
 sudo pip install sphinx
 ```
 
-For the test suite make sure you still have the exported environment variables above and then do the following in a directory separate from the API:
+For the test suite do the following in a directory separate from the API:
 
 ```shell
 git clone https://github.com/google/googletest

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -43,7 +43,7 @@ For the test suite:
 Debian 8 (Jessie)
 ^^^^^^^^^^^^^^^^^
 
-Debian Jessie will only compile if the latest CLang is along with LLVM's libc++, it also requires packages that are not in the main repositories. First of all you need Debian's Jessie backports repository enabled, edit the file ``/etc/apt/sources/list`` and add the following line:
+Debian Jessie requires packages that are not in the main repositories. First of all you need Debian's Jessie backports repository enabled, edit the file ``/etc/apt/sources/list`` and add the following line:
 
 .. code-block:: sourceslist
 
@@ -54,16 +54,7 @@ Then install the following:
 
 .. code-block:: console
 
-   sudo apt-get install cmake g++ libuv1-dev libxml2-dev libsnappy-dev pkg-config clang-3.8 libc++-dev swig python-dev default-jdk
-
-
-Now set the following environment variables so that CLang is used to compile:
-
-.. code-block:: console
-
-   export CC=clang-3.8
-   export CXX=clang++-3.8
-   export CXXFLAGS=-stdlib=libc++
+   sudo apt-get install cmake g++ libuv1-dev libxml2-dev libsnappy-dev pkg-config libc++-dev swig python-dev default-jdk
 
 For the documentation:
 
@@ -72,7 +63,7 @@ For the documentation:
    sudo apt-get install python-sphinx texlive-latex-recommended texlive-latex-extra latexmk python-pip
    sudo pip install python-sphinx
 
-For the test suite make sure you still have the exported environment variables above and then do the following in a directory separate from the API:
+For the test suite do the following in a directory separate from the API:
 
 .. code-block:: console
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,10 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__FILENAME__='\"$(subst ${CMAKE_SOURCE
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILDING_MCSAPI")
 
+if (HAVE_GET_TIME)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_GET_TIME=1")
+endif()
+
 set(SOURCE_FILES
     mcsapi_driver.cpp
     mcsapi_types.cpp

--- a/src/mcsapi_types.cpp
+++ b/src/mcsapi_types.cpp
@@ -84,13 +84,16 @@ bool ColumnStoreDateTime::set(tm& time)
 bool ColumnStoreDateTime::set(const std::string& dateTime, const std::string& format)
 {
     tm time = tm();
+#ifdef HAVE_GET_TIME
     std::istringstream ss(dateTime);
     ss >> std::get_time(&time, format.c_str());
     if (ss.fail())
     {
         return false;
     }
-
+#else
+    strptime(dateTime.c_str(), format.c_str(), &time);
+#endif
     return set(time);
 }
 


### PR DESCRIPTION
The std::get_time function was not in GCC 4.9 which makes builds on Debian
8 quite problematic. The function can be substituted with the strptime
POSIX function.