### PR TITLE
MCOL-1044 Fix Java library prefix

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -17,21 +17,61 @@ include_directories(${JNI_INCLUDE_DIRS})
 set(CMAKE_SWIG_FLAGS -package com.mariadb.columnstore.api)
 set(CMAKE_SWIG_OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/src/main/java/com/mariadb/columnstore/api")
 set_source_files_properties( javamcsapi.i PROPERTIES CPLUSPLUS ON)
-swig_add_module(javamcsapi java javamcsapi.i)
+IF (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.0)
+  swig_add_module(javamcsapi java javamcsapi.i)
+ELSE ()
+
+macro(SWIG_ADD_MODULE_JAVA name language)
+  string(TOUPPER "${language}" swig_uppercase_language)
+  string(TOLOWER "${language}" swig_lowercase_language)
+  set(SWIG_MODULE_${name}_LANGUAGE "${swig_uppercase_language}")
+  set(SWIG_MODULE_${name}_SWIG_LANGUAGE_FLAG "${swig_lowercase_language}")
+
+  set(SWIG_MODULE_${name}_REAL_NAME "${name}")
+  set(swig_dot_i_sources)
+  set(swig_other_sources)
+  foreach(it ${ARGN})
+    if(${it} MATCHES ".*\\.i$")
+      set(swig_dot_i_sources ${swig_dot_i_sources} "${it}")
+    else()
+      set(swig_other_sources ${swig_other_sources} "${it}")
+    endif()
+  endforeach()
+
+  set(swig_generated_sources)
+  foreach(it ${swig_dot_i_sources})
+    SWIG_ADD_SOURCE_TO_MODULE(${name} swig_generated_source ${it})
+    set(swig_generated_sources ${swig_generated_sources} "${swig_generated_source}")
+  endforeach()
+  get_directory_property(swig_extra_clean_files ADDITIONAL_MAKE_CLEAN_FILES)
+  set_directory_properties(PROPERTIES
+    ADDITIONAL_MAKE_CLEAN_FILES "${swig_extra_clean_files};${swig_generated_sources}")
+  add_library(${SWIG_MODULE_${name}_REAL_NAME}
+    MODULE
+    ${swig_generated_sources}
+    ${swig_other_sources})
+  string(TOLOWER "${language}" swig_lowercase_language)
+  if ("${swig_lowercase_language}" STREQUAL "java")
+    if (APPLE)
+        # In java you want:
+        #      System.loadLibrary("LIBRARY");
+        # then JNI will look for a library whose name is platform dependent, namely
+        #   MacOS  : libLIBRARY.jnilib
+        #   Windows: LIBRARY.dll
+        #   Linux  : libLIBRARY.so
+        set_target_properties (${SWIG_MODULE_${name}_REAL_NAME} PROPERTIES SUFFIX ".jnilib")
+      endif ()
+  endif ()
+  set_target_properties(${SWIG_MODULE_${name}_REAL_NAME} PROPERTIES PREFIX "")
+endmacro()
+swig_add_module_java(javamcsapi java javamcsapi.i)
+ENDIF ()
 swig_link_libraries(javamcsapi mcsapi)
 
-# SWIG behaves differently in Ubuntu's CMake
-IF (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.0)
-  ADD_CUSTOM_COMMAND(TARGET javamcsapi POST_BUILD
-      COMMAND "${CMAKE_CURRENT_BINARY_DIR}/gradlew" jar
-  )
-  INSTALL(TARGETS javamcsapi DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libs)
-ELSE ()
-  ADD_CUSTOM_COMMAND(TARGET _javamcsapi POST_BUILD
-      COMMAND "${CMAKE_CURRENT_BINARY_DIR}/gradlew" jar
-  )
-  INSTALL(TARGETS _javamcsapi DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libs)
-ENDIF()
+ADD_CUSTOM_COMMAND(TARGET javamcsapi POST_BUILD
+    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/gradlew" jar
+)
+INSTALL(TARGETS javamcsapi DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libs)
 IF(TEST_RUNNER)
   add_test(NAME Java_BasicTest COMMAND "${CMAKE_CURRENT_BINARY_DIR}/gradlew" test)
 ENDIF(TEST_RUNNER)


### PR DESCRIPTION
The Java library has an underscore prefix in CMake < 3.0 due to a bug in
the SWIG CMake wrapper. This patch adds a copy of the macro modified to
trim off the added prefix.