### PR TITLE
MCOL-1079 Raise exception when table lock fails

### DIFF
--- a/docs/reference/driver.rst
+++ b/docs/reference/driver.rst
@@ -77,6 +77,7 @@ createBulkInsert()
    :param mode: Future use, must be set to ``0``
    :param pm: Future use, must be set to ``0``
    :returns: An instance of :cpp:class:`ColumnStoreBulkInsert`
+   :raises ColumnStoreServerError: If a table lock cannot be acquired for the desired table
 
 Example
 ^^^^^^^

--- a/src/util_commands.cpp
+++ b/src/util_commands.cpp
@@ -21,6 +21,8 @@
 #include <libxml/xmlmemory.h>
 #include <libxml/parser.h>
 
+#include <sstream>
+
 #include "mcsapi_driver_impl.h"
 #include "mcsapi_types_impl.h"
 
@@ -278,6 +280,15 @@ uint64_t ColumnStoreCommands::brmGetTableLock(uint32_t tableOID, uint32_t sessio
     *messageOut >> tblLock.ownerName;
     *messageOut >> tblLock.sessionID;
     *messageOut >> tblLock.ownerTxnID;
+
+    std::stringstream errmsg;
+
+    errmsg << "Table already locked by PID: " << tblLock.ownerPID;
+    errmsg << " '" << tblLock.ownerName << "'";
+    errmsg << " session ID: " << tblLock.sessionID;
+    errmsg << " txn ID: " << tblLock.ownerTxnID;
+    delete messageOut;
+    throw ColumnStoreServerError(errmsg.str());
 
     delete messageOut;
     return 0;

--- a/src/util_commands.cpp
+++ b/src/util_commands.cpp
@@ -289,8 +289,6 @@ uint64_t ColumnStoreCommands::brmGetTableLock(uint32_t tableOID, uint32_t sessio
     errmsg << " txn ID: " << tblLock.ownerTxnID;
     delete messageOut;
     throw ColumnStoreServerError(errmsg.str());
-
-    delete messageOut;
     return 0;
 }
 

--- a/test/bad-usage.cpp
+++ b/test/bad-usage.cpp
@@ -202,6 +202,19 @@ TEST(BadUsage, WriteAfterReset)
     delete driver;
 }
 
+/* Test assert on table lock */
+TEST(BadUsage, AssertTableLock)
+{
+    std::string table("badusage");
+    std::string db("mcsapi");
+    mcsapi::ColumnStoreDriver* driver;
+    mcsapi::ColumnStoreBulkInsert* bulk;
+    driver = new mcsapi::ColumnStoreDriver();
+    bulk = driver->createBulkInsert(db, table, 0, 0);
+    ASSERT_THROW(driver->createBulkInsert(db, table, 0, 0), mcsapi::ColumnStoreServerError);
+    delete bulk;
+    delete driver;
+}
 
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
We were previously ignoring table lock failures and just allowing the
bulk insert to continue anyway. Now a pre-existing table lock is a hard
failure.