### PR TITLE
MCOL-1087 - Debian package dependencies added

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ CentOS 6 is not currently supported and it is not expected that the API will bui
 For the main build you need:
 
 ```shell
-sudo apt-get install cmake g++ libuv1-dev libxml2-dev libsnappy-dev pkg-config swig python-dev default-jdk default-libmysqlclient-dev
+sudo apt-get install cmake g++ libuv1-dev libxml2-dev libsnappy-dev pkg-config swig python-dev default-jdk
 ```
 
 For the documentation:
@@ -30,7 +30,7 @@ sudo apt-get install python-sphinx texlive-latex-recommended texlive-latex-extra
 For test test suite:
 
 ```shell
-sudo apt-get install libgtest-dev cppcheck
+sudo apt-get install libgtest-dev cppcheck default-libmysqlclient-dev
 cd /usr/src/gtest
 sudo cmake . -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_SHARED_LIBS=ON
 sudo make
@@ -47,7 +47,7 @@ deb http://httpredir.debian.org/debian jessie-backports main contrib non-free
 Then install the following:
 
 ```shell
-sudo apt-get install cmake g++ libuv1-dev libxml2-dev libsnappy-dev pkg-config libc++-dev swig python-dev libmysqlclient-dev
+sudo apt-get install cmake g++ libuv1-dev libxml2-dev libsnappy-dev pkg-config libc++-dev swig python-dev
 ```
 
 A JavaSDK >= 8 is required to run properly. If not installed do the following:
@@ -69,7 +69,7 @@ sudo pip install sphinx
 For the test suite do the following in a directory separate from the API:
 
 ```shell
-sudo apt-get install cppcheck
+sudo apt-get install cppcheck libmysqlclient-dev
 git clone https://github.com/google/googletest
 cd googletest
 cmake . -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_SHARED_LIBS=ON

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ CentOS 6 is not currently supported and it is not expected that the API will bui
 For the main build you need:
 
 ```shell
-sudo apt-get install cmake g++ libuv1-dev libxml2-dev libsnappy-dev pkg-config swig python-dev default-jdk
+sudo apt-get install cmake g++ libuv1-dev libxml2-dev libsnappy-dev pkg-config swig python-dev default-jdk default-libmysqlclient-dev
 ```
 
 For the documentation:
@@ -47,7 +47,16 @@ deb http://httpredir.debian.org/debian jessie-backports main contrib non-free
 Then install the following:
 
 ```shell
-sudo apt-get install cmake g++ libuv1-dev libxml2-dev libsnappy-dev pkg-config libc++-dev swig python-dev default-jdk
+sudo apt-get install cmake g++ libuv1-dev libxml2-dev libsnappy-dev pkg-config libc++-dev swig python-dev libmysqlclient-dev
+```
+
+A JavaSDK >= 8 is required to run properly. If not installed do the following:
+```shell
+sudo apt-get install -t jessie-backports openjdk-8-jdk
+```
+If more than one JavaSDK is installed, change the default to >= 8 by:
+```shell
+sudo update-alternatives --config java
 ```
 
 For the documentation:
@@ -60,6 +69,7 @@ sudo pip install sphinx
 For the test suite do the following in a directory separate from the API:
 
 ```shell
+sudo apt-get install cppcheck
 git clone https://github.com/google/googletest
 cd googletest
 cmake . -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_SHARED_LIBS=ON


### PR DESCRIPTION
Added Debian packet dependencies to documentation and changed to use Java SDK 8 instead of 7 for Debian  8