### PR TITLE
MCOL-1108 Add DBRM rollback

### DIFF
--- a/src/mcsapi_bulk.cpp
+++ b/src/mcsapi_bulk.cpp
@@ -342,6 +342,7 @@ void ColumnStoreBulkInsert::rollback()
         mImpl->commands->weRemoveMeta(pmit, mImpl->uniqueId, mImpl->tbl->getOID());
         mImpl->commands->weClose(pmit);
     }
+    mImpl->commands->brmRolledback(mImpl->txnId);
     mImpl->commands->brmReleaseTableLock(mImpl->tblLock);
     mImpl->autoRollback = false;
     mImpl->transactionClosed = true;

--- a/src/util_commands.cpp
+++ b/src/util_commands.cpp
@@ -1015,7 +1015,7 @@ void ColumnStoreCommands::brmRolledback(uint32_t txnId)
     *messageOut >> response;
     if (response != 0)
     {
-        std::string errmsg("Error committing BRM");
+        std::string errmsg("Error rolling back BRM");
         delete messageOut;
         throw ColumnStoreServerError(errmsg);
     }

--- a/src/util_commands.cpp
+++ b/src/util_commands.cpp
@@ -991,6 +991,38 @@ void ColumnStoreCommands::brmCommitted(uint32_t txnId)
     delete messageOut;
 }
 
+void ColumnStoreCommands::brmRolledback(uint32_t txnId)
+{
+    ColumnStoreMessaging messageIn;
+    ColumnStoreMessaging* messageOut;
+    ColumnStoreNetwork *connection = getBrmConnection();
+    runSoloLoop(connection);
+
+    uint8_t command = COMMAND_DBRM_ROLLEDBACK;
+
+    messageIn << command;
+    messageIn << txnId;
+    uint8_t valid = 1;
+    messageIn << valid;
+    connection->sendData(messageIn);
+    runSoloLoop(connection);
+
+    connection->readDataStart();
+    messageOut = connection->getReadMessage();
+    runSoloLoop(connection);
+
+    uint8_t response;
+    *messageOut >> response;
+    if (response != 0)
+    {
+        std::string errmsg("Error committing BRM");
+        delete messageOut;
+        throw ColumnStoreServerError(errmsg);
+    }
+
+    delete messageOut;
+}
+
 void ColumnStoreCommands::brmTakeSnapshot()
 {
     ColumnStoreMessaging messageIn;

--- a/src/util_commands.h
+++ b/src/util_commands.h
@@ -31,6 +31,7 @@ enum columnstore_commands_t
     COMMAND_DBRM_BULK_SET_HWM_AND_CP = 0x28,
     COMMAND_DBRM_GET_TXN_ID = 0x2E,
     COMMAND_DBRM_COMMITTED = 0x2F,
+    COMMAND_DBRM_ROLLEDBACK = 0x30,
     COMMAND_DBRM_GET_UNIQUE_ID = 0x38,
     COMMAND_DBRM_GET_TABLE_LOCK = 0x46,
     COMMAND_DBRM_RELEASE_TABLE_LOCK = 0x47,
@@ -69,6 +70,7 @@ public:
     void brmSetHWMAndCP(std::vector<ColumnStoreHWM>& hwms, std::vector<uint64_t>& lbids, uint32_t txnId);
     void brmVBCommit(uint32_t txnId);
     void brmCommitted(uint32_t txnId);
+    void brmRolledback(uint32_t txnId);
     void brmReleaseTableLock(uint64_t lockId);
     void brmGetUncommittedLbids(uint32_t txnId, std::vector<uint64_t>& lbids);
     void brmTakeSnapshot();


### PR DESCRIPTION
We weren't sending the DBRM rollback command which left an orphaned
transaction inside the DBRM when a rollback occurred. This wasn't
obvious until mcsadmin restart.