### PR TITLE
Mcol 1048

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ src/libmcsapi.a
 *.swp
 example/basic_bulk_insert
 example/advanced_bulk_insert
+example/CpImport/.gradle
 install_manifest*.txt
 src/libmcsapi.so*
 python/_pymcsapi*.so*

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -23,7 +23,12 @@ IF(TEST_RUNNER)
   add_test(NAME test_million_row COMMAND ${PYTHON_EXECUTABLE} -m pytest test/test_million_row.py)
 ENDIF(TEST_RUNNER)
 
-execute_process(COMMAND python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(PYTHON_VERSION_MAJOR LESS 3)
+	execute_process(COMMAND python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
+else(PYTHON_VERSION_MAJOR LESS 3)
+	execute_process(COMMAND python3 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif(PYTHON_VERSION_MAJOR LESS 3)
+
 install(TARGETS _pymcsapi DESTINATION ${PYTHON_SITE_PACKAGES})
 install(FILES pymcsapi.py DESTINATION ${PYTHON_SITE_PACKAGES})
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.8)
 
 include_directories(..)
 
@@ -23,11 +23,11 @@ IF(TEST_RUNNER)
   add_test(NAME test_million_row COMMAND ${PYTHON_EXECUTABLE} -m pytest test/test_million_row.py)
 ENDIF(TEST_RUNNER)
 
-if(PYTHON_VERSION_MAJOR LESS 3)
+if(PYTHONLIBS_VERSION_STRING LESS 3)
 	execute_process(COMMAND python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
-else(PYTHON_VERSION_MAJOR LESS 3)
+else(PYTHONLIBS_VERSION_STRING LESS 3)
 	execute_process(COMMAND python3 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif(PYTHON_VERSION_MAJOR LESS 3)
+endif(PYTHONLIBS_VERSION_STRING LESS 3)
 
 install(TARGETS _pymcsapi DESTINATION ${PYTHON_SITE_PACKAGES})
 install(FILES pymcsapi.py DESTINATION ${PYTHON_SITE_PACKAGES})


### PR DESCRIPTION
If python3-dev is installed python3 is used by default.
Otherwise python2.
Tested with Ubuntu 16.04 for Pyhon 2.7 and 3.5 and Debian 9 for Python 3.5