### PR TITLE
MCOL-1133 Fix Decimal trunc and neg

### DIFF
--- a/src/mcsapi_types.cpp
+++ b/src/mcsapi_types.cpp
@@ -402,7 +402,7 @@ uint64_t ColumnStoreDecimalImpl::getDecimalInt(uint32_t scale)
 
 int64_t ColumnStoreDecimalImpl::getInt()
 {
-    int64_t result = decimalNumber / pow((double)10, decimalScale);
+    int64_t result = llround(getDouble());
     return result;
 }
 

--- a/src/mcsapi_types.cpp
+++ b/src/mcsapi_types.cpp
@@ -297,6 +297,7 @@ bool ColumnStoreDecimal::set(const std::string& value)
     // Copy so as not to destroy original
     std::string valCopy = value;
 
+    errno = 0;
     token = strtok(&valCopy[0], seps);
     // No decimal point
     if (!token)
@@ -313,7 +314,13 @@ bool ColumnStoreDecimal::set(const std::string& value)
             return false;
         }
     }
-    mImpl->decimalNumber = atoll(token);
+    char* tokend;
+    mImpl->decimalNumber = strtoll(token, &tokend, 10);
+    if (errno == ERANGE)
+    {
+        return false;
+    }
+    size_t digits = tokend - token;
     token = strtok(NULL, seps);
 
     // Whatever is after the dot isn't a number
@@ -321,10 +328,39 @@ bool ColumnStoreDecimal::set(const std::string& value)
     {
         return false;
     }
-    int64_t decimals = atoll(token);
-    mImpl->decimalScale = strlen(token);
+    int64_t decimals = strtoll(token, NULL, 10);
+    digits += strlen(token);
+    if (digits > 18)
+    {
+        decimals = decimals / pow(10, (digits - 18));
+        digits = digits - 18;
+    }
+    else
+    {
+        digits = 0;
+    }
+    if (errno == ERANGE)
+    {
+        return false;
+    }
+    mImpl->decimalScale = strlen(token) - digits;
     mImpl->decimalNumber *= pow((double) 10, mImpl->decimalScale);
-    mImpl->decimalNumber += decimals;
+    if (errno == ERANGE)
+    {
+        return false;
+    }
+    if (mImpl->decimalNumber >= 0)
+    {
+        mImpl->decimalNumber += decimals;
+    }
+    else
+    {
+        mImpl->decimalNumber -= decimals;
+    }
+    if (errno == ERANGE)
+    {
+        return false;
+    }
 
     token = strtok(NULL, seps);
     // Something bad happened

--- a/test/dataconvert-decimal.cpp
+++ b/test/dataconvert-decimal.cpp
@@ -117,7 +117,7 @@ TEST(DataConvertDecimal, DataConvertDecimal)
     dblval = std::stod(strval);
     ASSERT_DOUBLE_EQ(dblval, 1000);
     row = mysql_fetch_row(result);
-    ASSERT_STREQ(row[0], "112345");
+    ASSERT_STREQ(row[0], "112346");
     ASSERT_STREQ(row[1], "112345.67");
     ASSERT_STREQ(row[2], "112345.6700");
     strval = row[3];
@@ -159,7 +159,25 @@ TEST(DataConvertDecimal, MCOL1133)
         bulk->setColumn(2, dData);
         bulk->setColumn(3, dData);
         bulk->writeRow();
-        dData.set(-23.42);
+        dData.set("-23.42");
+        bulk->setColumn(0, dData);
+        bulk->setColumn(1, dData);
+        bulk->setColumn(2, dData);
+        bulk->setColumn(3, dData);
+        bulk->writeRow();
+        dData.set("999999999.999999999"); //max value check
+        bulk->setColumn(0, dData);
+        bulk->setColumn(1, dData);
+        bulk->setColumn(2, dData);
+        bulk->setColumn(3, dData);
+        bulk->writeRow();
+        dData.set("1000000000.1234567890123"); //overflow check 
+        bulk->setColumn(0, dData);
+        bulk->setColumn(1, dData);
+        bulk->setColumn(2, dData);
+        bulk->setColumn(3, dData);
+        bulk->writeRow();
+        dData.set("999999999.999999999999999"); //overflow check
         bulk->setColumn(0, dData);
         bulk->setColumn(1, dData);
         bulk->setColumn(2, dData);
@@ -174,11 +192,11 @@ TEST(DataConvertDecimal, MCOL1133)
     MYSQL_RES* result = mysql_store_result(my_con);
     if (!result)
         FAIL() << "Could not get result data: " << mysql_error(my_con);
-    ASSERT_EQ(mysql_num_rows(result), 2);
+    ASSERT_EQ(mysql_num_rows(result), 5);
     MYSQL_ROW row = mysql_fetch_row(result);
     double dblval;
     std::string strval;
-    ASSERT_STREQ(row[0], "100000000");
+    ASSERT_STREQ(row[0], "100000001");
     ASSERT_STREQ(row[1], "100000000.999999000");
     ASSERT_STREQ(row[2], "100000000.999999000");
     strval = row[3];
@@ -186,11 +204,32 @@ TEST(DataConvertDecimal, MCOL1133)
     ASSERT_DOUBLE_EQ(dblval, 100000000.999999000);
     row = mysql_fetch_row(result);
     ASSERT_STREQ(row[0], "-23");
-    ASSERT_STREQ(row[1], "-23.420000");
+    ASSERT_STREQ(row[1], "-23.42");
     ASSERT_STREQ(row[2], "-23.420000000");
     strval = row[3];
     dblval = std::stod(strval);
     ASSERT_DOUBLE_EQ(dblval, -23.42);
+    row = mysql_fetch_row(result);
+    ASSERT_STREQ(row[0], "1000000000");
+    ASSERT_STREQ(row[1], "999999999.999999999");
+    ASSERT_STREQ(row[2], "999999999.999999999");
+    strval = row[3];
+    dblval = std::stod(strval);
+    ASSERT_DOUBLE_EQ(dblval, 999999999.999999999);
+    row = mysql_fetch_row(result);
+    ASSERT_STREQ(row[0], "1000000000");
+    ASSERT_STREQ(row[1], "1000000000.12345678");
+    ASSERT_STREQ(row[2], "999999999.999999999");
+    strval = row[3];
+    dblval = std::stod(strval);
+    ASSERT_DOUBLE_EQ(dblval, 1000000000.1234567890123);
+    row = mysql_fetch_row(result);
+    ASSERT_STREQ(row[0], "1000000000");
+    ASSERT_STREQ(row[1], "999999999.999999999");
+    ASSERT_STREQ(row[2], "999999999.999999999");
+    strval = row[3];
+    dblval = std::stod(strval);
+    ASSERT_DOUBLE_EQ(dblval, 999999999.999999999999999);
     mysql_free_result(result);
     delete bulk;
     delete driver;

--- a/test/dataconvert-decimal.cpp
+++ b/test/dataconvert-decimal.cpp
@@ -42,12 +42,20 @@ class TestEnvironment : public ::testing::Environment {
         FAIL() << "Could not drop existing table: " << mysql_error(my_con);
     if (mysql_query(my_con, "CREATE TABLE IF NOT EXISTS dataconvertdecimal (a int, b varchar(50), c decimal(10,4), d double) engine=columnstore"))
         FAIL() << "Could not create table: " << mysql_error(my_con);
+        if (mysql_query(my_con, "DROP TABLE IF EXISTS dataconvertdecimal2"))
+        FAIL() << "Could not drop existing table: " << mysql_error(my_con);
+    if (mysql_query(my_con, "CREATE TABLE IF NOT EXISTS dataconvertdecimal2 (a int, b varchar(50), c decimal(18,9), d double) engine=columnstore"))
+        FAIL() << "Could not create table: " << mysql_error(my_con);
   }
   // Override this to define how to tear down the environment.
   virtual void TearDown()
   {
     if (my_con)
     {
+        if (mysql_query(my_con, "DROP TABLE dataconvertdecimal"))
+            FAIL() << "Could not drop table: " << mysql_error(my_con);
+        if (mysql_query(my_con, "DROP TABLE dataconvertdecimal2"))
+            FAIL() << "Could not drop table: " << mysql_error(my_con);
         mysql_close(my_con);
     }
   }
@@ -130,11 +138,64 @@ TEST(DataConvertDecimal, DataConvertDecimal)
     dblval = std::stod(strval);
     ASSERT_DOUBLE_EQ(dblval, 0);
     mysql_free_result(result);
-    if (mysql_query(my_con, "DROP TABLE dataconvertdecimal"))
-        FAIL() << "Could not drop table: " << mysql_error(my_con);
     delete bulk;
     delete driver;
 }
+
+/* Test that dataconvert issues in MCOL-1133 */
+TEST(DataConvertDecimal, MCOL1133)
+{
+    std::string table("dataconvertdecimal2");
+    std::string db("mcsapi");
+    mcsapi::ColumnStoreDriver* driver;
+    mcsapi::ColumnStoreBulkInsert* bulk;
+    try {
+        driver = new mcsapi::ColumnStoreDriver();
+        bulk = driver->createBulkInsert(db, table, 0, 0);
+        mcsapi::ColumnStoreDecimal dData;
+        dData.set("100000000.999999000000000");
+        bulk->setColumn(0, dData);
+        bulk->setColumn(1, dData);
+        bulk->setColumn(2, dData);
+        bulk->setColumn(3, dData);
+        bulk->writeRow();
+        dData.set(-23.42);
+        bulk->setColumn(0, dData);
+        bulk->setColumn(1, dData);
+        bulk->setColumn(2, dData);
+        bulk->setColumn(3, dData);
+        bulk->writeRow();
+        bulk->commit();
+    } catch (mcsapi::ColumnStoreError &e) {
+        FAIL() << "Error caught: " << e.what() << std::endl;
+    }
+    if (mysql_query(my_con, "SELECT * FROM dataconvertdecimal2"))
+        FAIL() << "Could not run test query: " << mysql_error(my_con);
+    MYSQL_RES* result = mysql_store_result(my_con);
+    if (!result)
+        FAIL() << "Could not get result data: " << mysql_error(my_con);
+    ASSERT_EQ(mysql_num_rows(result), 2);
+    MYSQL_ROW row = mysql_fetch_row(result);
+    double dblval;
+    std::string strval;
+    ASSERT_STREQ(row[0], "100000000");
+    ASSERT_STREQ(row[1], "100000000.999999000");
+    ASSERT_STREQ(row[2], "100000000.999999000");
+    strval = row[3];
+    dblval = std::stod(strval);
+    ASSERT_DOUBLE_EQ(dblval, 100000000.999999000);
+    row = mysql_fetch_row(result);
+    ASSERT_STREQ(row[0], "-23");
+    ASSERT_STREQ(row[1], "-23.420000");
+    ASSERT_STREQ(row[2], "-23.420000000");
+    strval = row[3];
+    dblval = std::stod(strval);
+    ASSERT_DOUBLE_EQ(dblval, -23.42);
+    mysql_free_result(result);
+    delete bulk;
+    delete driver;
+}
+
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
If a decimal was set via a string:

1. the number of digits could cause an overflow and bad data
2. negative numbers were corrupted

This patch trims numbers that are too large to store and fixes support
for negative numbers