### PR TITLE
MCOL-1147 Fix sessionID/txnID reuse

### DIFF
--- a/src/mcsapi_bulk.cpp
+++ b/src/mcsapi_bulk.cpp
@@ -372,7 +372,6 @@ ColumnStoreBulkInsertImpl::ColumnStoreBulkInsertImpl(const std::string& iDb, con
     uniqueId(0),
     tblLock(0),
     txnId(0),
-    sessionId(65535), // Maybe change this later?
     row(nullptr),
     batchSize(10000),
     autoRollback(true),
@@ -380,6 +379,7 @@ ColumnStoreBulkInsertImpl::ColumnStoreBulkInsertImpl(const std::string& iDb, con
     truncateIsError(false),
     currentPm(0)
 {
+    sessionId = rand() % 65535 + 65535;
     summary = new ColumnStoreSummary();
     if (iMode == 1)
     {

--- a/src/mcsapi_driver.cpp
+++ b/src/mcsapi_driver.cpp
@@ -33,6 +33,9 @@ ColumnStoreDriver::ColumnStoreDriver(const std::string& path)
     mImpl->path = path;
     mImpl->loadXML();
     mcsdebug("loaded config: %s", path.c_str());
+    timeval t1;
+    gettimeofday(&t1, NULL);
+    srand(t1.tv_usec * t1.tv_sec);
 }
 
 ColumnStoreDriver::ColumnStoreDriver()
@@ -52,6 +55,9 @@ ColumnStoreDriver::ColumnStoreDriver()
 
     mImpl->loadXML();
     mcsdebug("loaded config: %s", mImpl->path.c_str());
+    timeval t1;
+    gettimeofday(&t1, NULL);
+    srand(t1.tv_usec * t1.tv_sec);
 }
 
 ColumnStoreDriver::~ColumnStoreDriver()

--- a/test/commit.cpp
+++ b/test/commit.cpp
@@ -42,6 +42,10 @@ class TestEnvironment : public ::testing::Environment {
         FAIL() << "Could not drop existing table: " << mysql_error(my_con);
     if (mysql_query(my_con, "CREATE TABLE IF NOT EXISTS commit (a int, b int) engine=columnstore"))
         FAIL() << "Could not create table: " << mysql_error(my_con);
+    if (mysql_query(my_con, "DROP TABLE IF EXISTS commit2"))
+        FAIL() << "Could not drop existing table: " << mysql_error(my_con);
+    if (mysql_query(my_con, "CREATE TABLE IF NOT EXISTS commit2 (a int, b int) engine=columnstore"))
+        FAIL() << "Could not create table: " << mysql_error(my_con);
   }
   // Override this to define how to tear down the environment.
   virtual void TearDown()
@@ -49,6 +53,8 @@ class TestEnvironment : public ::testing::Environment {
     if (my_con)
     {
         if (mysql_query(my_con, "DROP TABLE commit"))
+            FAIL() << "Could not drop table: " << mysql_error(my_con);
+        if (mysql_query(my_con, "DROP TABLE commit2"))
             FAIL() << "Could not drop table: " << mysql_error(my_con);
         mysql_close(my_con);
     }
@@ -181,6 +187,37 @@ TEST(Commit, SecondCommit)
     mysql_free_result(result);
     delete bulk;
     delete driver;
+}
+
+/* Test that two transactions work */
+TEST(Commit, TwoTransactions)
+{
+    std::string table("commit");
+    std::string table2("commit2");
+    std::string db("mcsapi");
+    mcsapi::ColumnStoreDriver* driver;
+    mcsapi::ColumnStoreBulkInsert* bulk;
+    mcsapi::ColumnStoreBulkInsert* bulk2;
+    try {
+        driver = new mcsapi::ColumnStoreDriver();
+        bulk = driver->createBulkInsert(db, table, 0, 0);
+        bulk2 = driver->createBulkInsert(db, table2, 0, 0);
+        for (int i = 0; i < 1000; i++)
+        {
+            bulk->setColumn(0, (uint32_t)i);
+            bulk->setColumn(1, (uint32_t)1000 - i);
+            bulk->writeRow();
+            bulk2->setColumn(0, (uint32_t)i);
+            bulk2->setColumn(1, (uint32_t)1000 - i);
+            bulk2->writeRow();
+        }
+        bulk->commit();
+        bulk2->commit();
+    } catch (mcsapi::ColumnStoreError &e) {
+        FAIL() << "Error caught: " << e.what() << std::endl;
+    }
+    delete bulk2;
+    delete bulk;
 }
 
 


### PR DESCRIPTION
If an mcsapi instance is currently running a second mcsapi instance will
end up with the same txnID since the sessionID is fixed and the engine
matches session to txn. This patch randomizes sessionID for each
instance.