### PR TITLE
MCOL-1154 trailing NULs in text corruption fix

### DIFF
--- a/src/util_dataconvert.cpp
+++ b/src/util_dataconvert.cpp
@@ -1442,6 +1442,17 @@ columnstore_data_convert_status_t ColumnStoreDataConvert::convert(ColumnStoreSys
         case DATA_TYPE_VARCHAR:
         case DATA_TYPE_CHAR:
         case DATA_TYPE_TEXT:
+        {
+           // Truncate trailing NUL characters for text fields
+           valStr = fromValue.substr(0, strlen(fromValue.c_str()));
+           if (valStr.length() > toMeta->getWidth())
+           {
+               status = CONVERT_STATUS_TRUNCATED;
+               valStr.resize(toMeta->getWidth());
+           }
+           cont->setData(valStr);
+           break;
+        }
         case DATA_TYPE_VARBINARY:
         case DATA_TYPE_CLOB:
         case DATA_TYPE_BLOB:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,4 +29,4 @@ compile_test(truncation)
 compile_test(summary)
 compile_test(system-catalog)
 compile_test(char4)
-
+compile_test(mcol1154)

--- a/test/mcol1154.cpp
+++ b/test/mcol1154.cpp
@@ -1,0 +1,105 @@
+/* Copyright (c) 2018, MariaDB Corporation. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+
+#include <libmcsapi/mcsapi.h>
+#include <iostream>
+#include <gtest/gtest.h>
+#include <mysql.h>
+
+MYSQL* my_con;
+
+class TestEnvironment : public ::testing::Environment {
+ public:
+  virtual ~TestEnvironment() {}
+  // Override this to define how to set up the environment.
+  virtual void SetUp()
+  {
+    my_con = mysql_init(NULL);
+    if (!my_con)
+        FAIL() << "Could not init MariaDB connection";
+    if (!mysql_real_connect(my_con, "127.0.0.1", "root", "", NULL, 3306, NULL, 0))
+        FAIL() << "Could not connect to MariaDB: " << mysql_error(my_con);
+    if (mysql_query(my_con, "CREATE DATABASE IF NOT EXISTS mcsapi"))
+        FAIL() << "Error creating database: " << mysql_error(my_con);
+    if (mysql_select_db(my_con, "mcsapi"))
+        FAIL() << "Could not select DB: " << mysql_error(my_con);
+    if (mysql_query(my_con, "DROP TABLE IF EXISTS mcol1154"))
+        FAIL() << "Could not drop existing table: " << mysql_error(my_con);
+    if (mysql_query(my_con, "CREATE TABLE IF NOT EXISTS mcol1154 (a int, b varchar(50)) engine=columnstore"))
+        FAIL() << "Could not create table: " << mysql_error(my_con);
+  }
+  // Override this to define how to tear down the environment.
+  virtual void TearDown()
+  {
+    if (my_con)
+    {
+        mysql_close(my_con);
+    }
+  }
+};
+
+
+/* Test that trailing NULs don't corrupt textual columns */
+TEST(mcol1154, mcol1154)
+{
+    std::string table("mcol1154");
+    std::string db("mcsapi");
+    mcsapi::ColumnStoreDriver* driver;
+    mcsapi::ColumnStoreBulkInsert* bulk;
+    try {
+        driver = new mcsapi::ColumnStoreDriver();
+        bulk = driver->createBulkInsert(db, table, 0, 0);
+        std::string tData;
+        tData = "hello world1";
+        // Pad end with some NULs
+        tData.resize(14);
+        bulk->setColumn(0, 1);
+        bulk->setColumn(1, tData);
+        bulk->writeRow();
+        tData = "hello world2";
+        bulk->setColumn(0, 2);
+        bulk->setColumn(1, tData);
+        bulk->writeRow();
+        bulk->commit();
+    } catch (mcsapi::ColumnStoreError &e) {
+        FAIL() << "Error caught: " << e.what() << std::endl;
+    }
+    if (mysql_query(my_con, "SELECT * FROM mcol1154"))
+        FAIL() << "Could not run test query: " << mysql_error(my_con);
+    MYSQL_RES* result = mysql_store_result(my_con);
+    if (!result)
+        FAIL() << "Could not get result data: " << mysql_error(my_con);
+    ASSERT_EQ(mysql_num_rows(result), 2);
+    MYSQL_ROW row = mysql_fetch_row(result);
+    ASSERT_STREQ(row[0], "1");
+    ASSERT_STREQ(row[1], "hello world1");
+    row = mysql_fetch_row(result);
+    ASSERT_STREQ(row[0], "2");
+    ASSERT_STREQ(row[1], "hello world2");
+    mysql_free_result(result);
+    if (mysql_query(my_con, "DROP TABLE mcol1154"))
+        FAIL() << "Could not drop table: " << mysql_error(my_con);
+    delete bulk;
+    delete driver;
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new TestEnvironment);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Trailing NULs to VARCHAR/CHAR/TEXT columns cause data corruption when
they are stored. This patch trims them for these data types.