### PR TITLE
MCOL-1168 Fix system catalog regression

### DIFF
--- a/libmcsapi/mcsapi_types.h
+++ b/libmcsapi/mcsapi_types.h
@@ -137,6 +137,7 @@ private:
 class MCS_API ColumnStoreSystemCatalogTable
 {
     friend class ColumnStoreCommands;
+    friend class ColumnStoreSystemCatalogImpl;
 public:
     ColumnStoreSystemCatalogTable();
     ColumnStoreSystemCatalogTable(const ColumnStoreSystemCatalogTable& obj);

--- a/src/mcsapi_driver.cpp
+++ b/src/mcsapi_driver.cpp
@@ -62,7 +62,6 @@ ColumnStoreDriver::ColumnStoreDriver()
 
 ColumnStoreDriver::~ColumnStoreDriver()
 {
-
     delete mImpl;
 }
 

--- a/src/mcsapi_types.cpp
+++ b/src/mcsapi_types.cpp
@@ -702,6 +702,7 @@ void ColumnStoreSystemCatalogImpl::clear()
 {
     for (std::vector<ColumnStoreSystemCatalogTable*>::iterator it = tables.begin() ; it != tables.end(); ++it)
     {
+        (*it)->mImpl->clear();
         delete *it;
     }
 }

--- a/src/mcsapi_types_impl.h
+++ b/src/mcsapi_types_impl.h
@@ -148,7 +148,6 @@ public:
     ColumnStoreSystemCatalogTableImpl() :
         oid(0)
     {}
-    ~ColumnStoreSystemCatalogTableImpl() { clear(); }
     void clear();
     uint32_t oid;
     std::string schema;


### PR DESCRIPTION
The memory leak fix to system catalog caused a double-free when the
references were cleaned up and triggered destructors.

This fix makes sure only the final cleanup deletes the system catalog
allocations