### PR TITLE
MCOL-1160 Fix dictionary flushing

### DIFF
--- a/src/mcsapi_bulk.cpp
+++ b/src/mcsapi_bulk.cpp
@@ -295,8 +295,6 @@ void ColumnStoreBulkInsert::commit()
         std::vector<uint64_t> lbids;
         std::vector<ColumnStoreHWM> hwms;
         mImpl->commands->weGetWrittenLbids(pmit, mImpl->uniqueId, mImpl->txnId, lbids);
-        mImpl->commands->weClose(pmit);
-        mImpl->commands->weKeepAlive(pmit);
         mImpl->commands->weBulkCommit(pmit, mImpl->uniqueId, mImpl->sessionId, mImpl->txnId, mImpl->tbl->getOID(), hwms);
         mImpl->commands->brmSetHWMAndCP(hwms, lbids, mImpl->txnId);
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,4 +29,4 @@ compile_test(truncation)
 compile_test(summary)
 compile_test(system-catalog)
 compile_test(char4)
-
+compile_test(mcol1160)

--- a/test/mcol1160.cpp
+++ b/test/mcol1160.cpp
@@ -1,0 +1,124 @@
+/* Copyright (c) 2018, MariaDB Corporation. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+
+#include <libmcsapi/mcsapi.h>
+#include <iostream>
+#include <gtest/gtest.h>
+#include <mysql.h>
+
+MYSQL* my_con;
+
+class TestEnvironment : public ::testing::Environment {
+ public:
+  virtual ~TestEnvironment() {}
+  // Override this to define how to set up the environment.
+  virtual void SetUp()
+  {
+    my_con = mysql_init(NULL);
+    if (!my_con)
+        FAIL() << "Could not init MariaDB connection";
+    if (!mysql_real_connect(my_con, "127.0.0.1", "root", "", NULL, 3306, NULL, 0))
+        FAIL() << "Could not connect to MariaDB: " << mysql_error(my_con);
+    if (mysql_query(my_con, "CREATE DATABASE IF NOT EXISTS mcsapi"))
+        FAIL() << "Error creating database: " << mysql_error(my_con);
+    if (mysql_select_db(my_con, "mcsapi"))
+        FAIL() << "Could not select DB: " << mysql_error(my_con);
+    if (mysql_query(my_con, "DROP TABLE IF EXISTS mcol1160"))
+        FAIL() << "Could not drop existing table: " << mysql_error(my_con);
+    if (mysql_query(my_con, "CREATE TABLE IF NOT EXISTS mcol1160 (a int, b varchar(64)) engine=columnstore comment='compression=0'"))
+        FAIL() << "Could not create table: " << mysql_error(my_con);
+  }
+  // Override this to define how to tear down the environment.
+  virtual void TearDown()
+  {
+    if (my_con)
+    {
+        mysql_close(my_con);
+    }
+  }
+};
+
+
+/* Test that trailing NULs don't corrupt textual columns */
+TEST(mcol1160, mcol1160)
+{
+    std::string table("mcol1160");
+    std::string db("mcsapi");
+    mcsapi::ColumnStoreDriver* driver;
+    mcsapi::ColumnStoreBulkInsert* bulk;
+    try {
+        driver = new mcsapi::ColumnStoreDriver();
+        bulk = driver->createBulkInsert(db, table, 0, 0);
+	bulk->setColumn(0, 1);
+	bulk->setColumn(1, "preload");
+	bulk->writeRow();
+	bulk->commit();
+        if (mysql_query(my_con, "SELECT * FROM mcol1160"))
+            FAIL() << "Could not run test query: " << mysql_error(my_con);
+        MYSQL_RES* result = mysql_store_result(my_con);
+        if (!result)
+            FAIL() << "Could not get result data: " << mysql_error(my_con);
+	mysql_free_result(result);
+	delete bulk;
+	bulk = driver->createBulkInsert(db, table, 0, 0);
+	bulk->setColumn(0, 1);
+        std::string tData("hello world1");
+        // Pad end with some NULs
+        //tData.resize(14);
+        bulk->setColumn(1, tData);
+        bulk->writeRow();
+        bulk->setColumn(0, 2);
+        bulk->setColumn(1, "hello world4");
+        bulk->writeRow();
+        bulk->setColumn(0, 3);
+        bulk->setColumn(1, "hello world9");
+        bulk->writeRow();
+        bulk->setColumn(0, 4);
+        bulk->setColumn(1, "hello world16");
+        bulk->writeRow();
+	bulk->commit();
+    } catch (mcsapi::ColumnStoreError &e) {
+        FAIL() << "Error caught: " << e.what() << std::endl;
+    }
+    if (mysql_query(my_con, "SELECT * FROM mcol1160"))
+        FAIL() << "Could not run test query: " << mysql_error(my_con);
+    MYSQL_RES* result = mysql_store_result(my_con);
+    if (!result)
+        FAIL() << "Could not get result data: " << mysql_error(my_con);
+    ASSERT_EQ(mysql_num_rows(result), 5);
+    MYSQL_ROW row = mysql_fetch_row(result);
+    ASSERT_STREQ(row[0], "1");
+    ASSERT_STREQ(row[1], "preload");
+    row = mysql_fetch_row(result);
+    ASSERT_STREQ(row[0], "1");
+    ASSERT_STREQ(row[1], "hello world1");
+    row = mysql_fetch_row(result);
+    ASSERT_STREQ(row[0], "2");
+    ASSERT_STREQ(row[1], "hello world4");
+    mysql_free_result(result);
+    if (mysql_query(my_con, "DROP TABLE mcol1160"))
+        FAIL() << "Could not drop table: " << mysql_error(my_con);
+    delete bulk;
+    delete driver;
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new TestEnvironment);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This patch requires the corresponding patch in the engine code to work
correctly (but won't stop API functioning without it).

It removes the second connection on commit so that the dict LBID flush
tracking doesn't get lost. It also adds a test