### PR TITLE
Mcol 1177

### DIFF
--- a/spark-connector/python/benchmark.sh
+++ b/spark-connector/python/benchmark.sh
@@ -5,7 +5,7 @@ if [ "$#" -ne 1 ]; then
     exit 2
 fi
 
-export PYSPARK_SUBMIT_ARGS="--jars $1 pyspark-shell"
+export PYSPARK_SUBMIT_ARGS="--jars $1 --driver-memory 10G pyspark-shell"
 
 PYTHON_VERSION_AVAILABLE=`python -c "import sys; print(sys.version_info[0]);"`
 

--- a/spark-connector/python/test/benchmark.py
+++ b/spark-connector/python/test/benchmark.py
@@ -135,7 +135,7 @@ def benchmark2():
     emptyDatabase()
     
     print("creating dataframe 1: two random generated doubles")
-    randDF = sqlContext.range(0, 10000000).withColumn('uniform', rand(seed=23)).withColumn('normal', randn(seed=42)).cache()
+    randDF = sqlContext.range(0, 7000000).withColumn('uniform', rand(seed=23)).withColumn('normal', randn(seed=42)).cache()
     randDFRows = randDF.count()
     randDFItems = randDFRows*len(randDF.columns)
     randDF.printSchema()
@@ -144,7 +144,7 @@ def benchmark2():
     randDF.unpersist()
     
     print("creating dataframe 2: sha1, sha256, sha512 and md5 hashes of integers")
-    tmpDF = sqlContext.createDataFrame(sc.parallelize(range(0, 1000000)).map(lambda i: Row(number=i, string=str(i))))
+    tmpDF = sqlContext.createDataFrame(sc.parallelize(range(0, 3000000)).map(lambda i: Row(number=i, string=str(i))))
     hashDF = tmpDF.select(tmpDF.number, sha1(tmpDF.string).alias("sha1"), sha2(tmpDF.string,256).alias("sha256"), sha2(tmpDF.string,512).alias("sha512"), md5(tmpDF.string).alias("md5")).cache()
     hashDFRows = hashDF.count()
     hashDFItems = hashDFRows*len(hashDF.columns)
@@ -154,9 +154,8 @@ def benchmark2():
     hashDF.unpersist()
     
     print("jdbc_innodb\tapi_columnstore\t\trows\t\titems")
-    print("%.3fs\t\t%.3fs\t\t\t%i\t\t%i" %(ascii_benchmark[0], ascii_benchmark[1], asciiDFRows, asciiDFItems))
-    print("%.3fs\t\t%.3fs\t\t\t%i\t\t%i" %(rand_benchmark[0], rand_benchmark[1], randDF.count(), randDFRows, randDFItems))
-    print("%.3fs\t\t%.3fs\t\t\t%i\t\t%i" %(hash_benchmark[0], hash_benchmark[1], hashDF.count(), hashDFRows, hashDFItems))
+    print("%.3fs\t\t%.3fs\t\t%i\t\t%i" %(rand_benchmark[0], rand_benchmark[1], randDFRows, randDFItems))
+    print("%.3fs\t\t%.3fs\t\t%i\t\t%i" %(hash_benchmark[0], hash_benchmark[1], hashDFRows, hashDFItems))
     
 def benchmark2execution(name, dataframe, schema):
     t = time.time()

--- a/spark-connector/scala/build.gradle
+++ b/spark-connector/scala/build.gradle
@@ -34,7 +34,9 @@ test {
 
 task benchmark(type: JavaExec, dependsOn: classes){
         main = 'com.mariadb.columnstore.api.connector.Benchmark'
+        jvmArgs = ['-Xms4g', '-Xmx10g']
         systemProperty "java.library.path","${project.projectDir}/../../java"
+        systemProperty "spark.driver.memory","10g"
         classpath sourceSets.test.runtimeClasspath
         classpath configurations.runtime
 }

--- a/spark-connector/scala/src/test/scala/com/mariadb/columnstore/api/connector/Benchmark.scala
+++ b/spark-connector/scala/src/test/scala/com/mariadb/columnstore/api/connector/Benchmark.scala
@@ -156,14 +156,15 @@ object Benchmark {
     val hashDF = sqlContext.sql("SELECT number, sha1(string) AS sha1, sha2(string,256) AS sha256, sha2(string,512) AS sha512, md5(string) AS md5 FROM tempDF").cache()
     val hashDFRows = hashDF.count()
     val hashDFItems = hashDFRows*hashDF.columns.size
+    tmpDF.unpersist()
     hashDF.printSchema()
     println("bemchmarking dataframe 2")
     val hash_benchmark = benchmark2execution("hash", hashDF, "number BIGINT, sha1 VARCHAR(40), sha256 VARCHAR(64), sha512 VARCHAR(128), md5 VARCHAR(32)")
     hashDF.unpersist()
     
     println("jdbc_innodb\tapi_columnstore\t\trows\t\titems")
-    println(rand_benchmark._1/1000000000.toDouble+"s\t"+rand_benchmark._2/1000000000.toDouble+"s\t\t"+randDF.count+"\t\t"+randDF.count*randDF.columns.size)
-    println(hash_benchmark._1/1000000000.toDouble+"s\t"+hash_benchmark._2/1000000000.toDouble+"s\t\t"+hashDF.count+"\t\t"+hashDF.count*hashDF.columns.size)
+    println(rand_benchmark._1/1000000000.toDouble+"s\t"+rand_benchmark._2/1000000000.toDouble+"s\t\t"+randDFRows+"\t\t"+randDFItems)
+    println(hash_benchmark._1/1000000000.toDouble+"s\t"+hash_benchmark._2/1000000000.toDouble+"s\t\t"+hashDFRows+"\t\t"+hashDFItems)
   }
   
   private def benchmark2execution(name: String, dataframe: DataFrame, schema: String) = {

--- a/spark-connector/scala/src/test/scala/com/mariadb/columnstore/api/connector/Benchmark.scala
+++ b/spark-connector/scala/src/test/scala/com/mariadb/columnstore/api/connector/Benchmark.scala
@@ -142,7 +142,7 @@ object Benchmark {
     emptyDatabase()
     
     println("creating dataframe 1: two random generated doubles")
-    val randDF = sqlContext.range(0, 10000000).withColumn("uniform", rand(seed=23)).withColumn("normal", randn(seed=42)).cache()
+    val randDF = sqlContext.range(0, 7000000).withColumn("uniform", rand(seed=23)).withColumn("normal", randn(seed=42)).cache()
     val randDFRows = randDF.count()
     val randDFItems = randDFRows*randDF.columns.size
     randDF.printSchema()
@@ -151,7 +151,7 @@ object Benchmark {
     randDF.unpersist()
     
     println("creating dataframe 2: sha1, sha256, sha512 and md5 hashes of integers")
-    val tmpDF = sc.makeRDD(0 until 1000000).map(i => (i, i.toString)).toDF("number", "string")
+    val tmpDF = sc.makeRDD(0 until 3000000).map(i => (i, i.toString)).toDF("number", "string")
     tmpDF.createOrReplaceTempView("tempDF")
     val hashDF = sqlContext.sql("SELECT number, sha1(string) AS sha1, sha2(string,256) AS sha256, sha2(string,512) AS sha512, md5(string) AS md5 FROM tempDF").cache()
     val hashDFRows = hashDF.count()


### PR DESCRIPTION
Fixed 2 bugs in the benchmark result output to command line.

Changed the amount of rows to write to 7000000 with regards to MCOL-1176 to be comparable.

Memory issue was a configuration matter. Both Scala and PySpark weren't executed with enough heap allocation. Fixed that to 10GiB max. Now the benchmark runs successfully.