### PR TITLE
MCOL-1213 system catalog is lower case

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,14 +3,16 @@ Version History
 
 This is a version history of C++ API interface changes. It does not include internal fixes and changes.
 
-+---------+----------------------------------------------------------------------------------------------+
-| Version | Changes                                                                                      |
-+=========+==============================================================================================+
-| 1.1.1   | - Add :cpp:func:`ColumnStoreBulkInsert::isActive`                                            |
-|         | - Make :cpp:func:`ColumnStoreBulkInsert::rollback` fail without error                        |
-|         | - Add :cpp:func:`ColumnStoreBulkInsert::resetRow`                                            |
-|         | - :cpp:func:`ColumnStoreDateTime::ColumnStoreDateTime` now uses uint32_t for every parameter |
-|         | - :cpp:class:`ColumnStoreSystemCatalog` now uses const for the sub-class strings             |
-+---------+----------------------------------------------------------------------------------------------+
-| 1.1.0β  | - First beta release                                                                         |
-+---------+----------------------------------------------------------------------------------------------+
++---------+---------------------------------------------------------------------------------------------------------------------------------------+
+| Version | Changes                                                                                                                               |
++=========+=======================================================================================================================================+
+| 1.1.4   | - Make :cpp:func:`ColumnStoreSystemCatalogColumn::getColumn` and :cpp:func:`ColumnStoreSystemCatalogTable::getTable` case insensitive |
++---------+---------------------------------------------------------------------------------------------------------------------------------------+
+| 1.1.1   | - Add :cpp:func:`ColumnStoreBulkInsert::isActive`                                                                                     |
+|         | - Make :cpp:func:`ColumnStoreBulkInsert::rollback` fail without error                                                                 |
+|         | - Add :cpp:func:`ColumnStoreBulkInsert::resetRow`                                                                                     |
+|         | - :cpp:func:`ColumnStoreDateTime::ColumnStoreDateTime` now uses uint32_t for every parameter                                          |
+|         | - :cpp:class:`ColumnStoreSystemCatalog` now uses const for the sub-class strings                                                      |
++---------+---------------------------------------------------------------------------------------------------------------------------------------+
+| 1.1.0β  | - First beta release                                                                                                                  |
++---------+---------------------------------------------------------------------------------------------------------------------------------------+

--- a/docs/reference/types.rst
+++ b/docs/reference/types.rst
@@ -280,6 +280,9 @@ ColumnStoreSystemCatalog Class
 
    A class which contains the ColumnStore system catalog of tables and columns. It should be instantiated using :cpp:func:`ColumnStoreDriver::getSystemCatalog`.
 
+   .. note::
+      The system catalog stores schema, table and column names as lower case and therefore the functions only return lower case names. Since version 1.1.4 we make case insensitive matches.
+
 getTable()
 ----------
 
@@ -298,6 +301,10 @@ ColumnStoreSystemCatalogTable Class
 .. cpp:class:: ColumnStoreSystemCatalogTable
 
    A class which contains the system catalog information for a specific table. It should be instantiated using :cpp:func:`ColumnStoreSystemCatalog::getTable`.
+
+   .. note::
+      The system catalog stores schema, table and column names as lower case and therefore the functions only return lower case names. Since version 1.1.4 we make case insensitive matches.
+
 
 getSchemaName()
 ---------------
@@ -361,6 +368,10 @@ ColumnStoreSystemCatalogColumn Class
 .. cpp:class:: ColumnStoreSystemCatalogColumn
 
    A class containing information about a specific column in the system catalog. Should be instantiated using :cpp:func:`ColumnStoreSystemCatalogTable::getColumn`.
+
+   .. note::
+      The system catalog stores schema, table and column names as lower case and therefore the functions only return lower case names. Since version 1.1.4 we make case insensitive matches.
+
 
 getOID()
 --------

--- a/src/mcsapi_types.cpp
+++ b/src/mcsapi_types.cpp
@@ -22,6 +22,8 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <cctype>
+#include <boost/algorithm/string.hpp>
 
 namespace mcsapi
 {
@@ -569,7 +571,7 @@ ColumnStoreSystemCatalogColumn& ColumnStoreSystemCatalogTable::getColumn(const s
     ColumnStoreSystemCatalogColumn* col = nullptr;
     for (auto& itColumn : mImpl->columns)
     {
-        if (columnName == itColumn->getColumnName())
+        if (boost::iequals(columnName,itColumn->getColumnName()))
         {
             col = itColumn;
             break;
@@ -599,7 +601,7 @@ ColumnStoreSystemCatalogTable& ColumnStoreSystemCatalog::getTable(const std::str
     ColumnStoreSystemCatalogTable* tbl = nullptr;
     for (auto& itTable : mImpl->tables)
     {
-        if ((schemaName == itTable->getSchemaName()) && (tableName == itTable->getTableName()))
+        if (boost::iequals(schemaName, itTable->getSchemaName()) && boost::iequals(tableName, itTable->getTableName()))
         {
             tbl = itTable;
             break;

--- a/test/system-catalog.cpp
+++ b/test/system-catalog.cpp
@@ -40,7 +40,7 @@ class TestEnvironment : public ::testing::Environment {
         FAIL() << "Could not select DB: " << mysql_error(my_con);
     if (mysql_query(my_con, "DROP TABLE IF EXISTS syscat"))
         FAIL() << "Could not drop existing table: " << mysql_error(my_con);
-    if (mysql_query(my_con, "CREATE TABLE IF NOT EXISTS syscat (a int, b int) engine=columnstore comment='compression=2'"))
+    if (mysql_query(my_con, "CREATE TABLE IF NOT EXISTS syscat (aCol int, bCol int) engine=columnstore comment='compression=2'"))
         FAIL() << "Could not create table: " << mysql_error(my_con);
   }
   // Override this to define how to tear down the environment.
@@ -72,7 +72,7 @@ TEST(SystemCatalog, NormalUsage)
         ASSERT_GE(tbl.getOID(), 3000);
         mcsapi::ColumnStoreSystemCatalogColumn col1 = tbl.getColumn(0);
         ASSERT_GE(col1.getOID(), 3000);
-        ASSERT_STREQ(col1.getColumnName().c_str(), "a");
+        ASSERT_STREQ(col1.getColumnName().c_str(), "acol");
         ASSERT_EQ(0, col1.getDictionaryOID());
         ASSERT_EQ(mcsapi::DATA_TYPE_INT, col1.getType());
         ASSERT_EQ(4, col1.getWidth());
@@ -84,9 +84,9 @@ TEST(SystemCatalog, NormalUsage)
         ASSERT_EQ(true, col1.isNullable());
         ASSERT_EQ(2, col1.compressionType());
 
-        mcsapi::ColumnStoreSystemCatalogColumn col2 = tbl.getColumn("b");
+        mcsapi::ColumnStoreSystemCatalogColumn col2 = tbl.getColumn("bCol");
         ASSERT_GE(col2.getOID(), 3000);
-        ASSERT_STREQ(col2.getColumnName().c_str(), "b");
+        ASSERT_STREQ(col2.getColumnName().c_str(), "bcol");
         ASSERT_EQ(0, col2.getDictionaryOID());
         ASSERT_EQ(mcsapi::DATA_TYPE_INT, col2.getType());
         ASSERT_EQ(4, col2.getWidth());


### PR DESCRIPTION
ColumnStore's system catalog is lower case so this patch makes system
catalog searches case insensitive. Therefore a user who created a table
with mixed/upper case naming can still reference the table.