### PR TITLE
MCOL 1296

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ This is a version history of C++ API interface changes. It does not include inte
 | Version | Changes                                                                                                                               |
 +=========+=======================================================================================================================================+
 | 1.1.4   | - Make :cpp:func:`ColumnStoreSystemCatalogColumn::getColumn` and :cpp:func:`ColumnStoreSystemCatalogTable::getTable` case insensitive |
+|         | - Add :cpp:func:`ColumnStoreDriver::setDebug` to enable debugging output to stderr                                                                                                                                      |
 +---------+---------------------------------------------------------------------------------------------------------------------------------------+
 | 1.1.1   | - Add :cpp:func:`ColumnStoreBulkInsert::isActive`                                                                                     |
 |         | - Make :cpp:func:`ColumnStoreBulkInsert::rollback` fail without error                                                                 |

--- a/docs/reference/driver.rst
+++ b/docs/reference/driver.rst
@@ -133,6 +133,39 @@ Example
        return 0;
    }
 
+setDebug()
+----------
+
+.. cpp:function:: void ColumnStoreDriver::setDebug(bool enabled)
+
+   Enables/disables verbose debugging output which is sent to stderr upon execution.
+
+   .. note::
+      This is a global setting which will apply to all instances of all of the API's classes after it is set until it is turned off.
+
+   :param enabled: Set to ``true`` to enable and ``false`` to disable.
+
+Example
+^^^^^^^
+.. code-block:: cpp
+   :linenos:
+
+   #include <iostream>
+   #include <libmcsapi/mcsapi.h>
+
+   int main(void)
+   {
+       try {
+           mcsapi::ColumnStoreDriver* driver = new mcsapi::ColumnStoreDriver();
+           driver->setDebug(true);
+           // Debugging output is now enabled
+       } catch (mcsapi::ColumnStoreError &e) {
+           std::cout << "Error caught: " << e.what() << std::endl;
+       }
+       return 0;
+   }
+
+
 getSystemCatalog()
 ------------------
 

--- a/java/javamcsapi.i
+++ b/java/javamcsapi.i
@@ -61,6 +61,12 @@
       jenv->ThrowNew( eclass, e.what() );
     }
   }
+  catch ( std::bad_alloc & er ) {
+    jclass eclass = jenv->FindClass("com/mariadb/columnstore/api/ColumnStoreException");
+    if ( eclass ) {
+      jenv->ThrowNew( eclass, er.what() );
+    }
+  }
 }
 
 %module javamcsapi

--- a/libmcsapi/mcsapi_driver.h
+++ b/libmcsapi/mcsapi_driver.h
@@ -31,6 +31,7 @@ public:
     ~ColumnStoreDriver();
 
     const char* getVersion();
+    void setDebug(bool enabled);
     ColumnStoreBulkInsert* createBulkInsert(const std::string& db,
             const std::string& table, uint8_t mode, uint16_t pm);
     ColumnStoreSystemCatalog& getSystemCatalog();

--- a/python/pymcsapi.i
+++ b/python/pymcsapi.i
@@ -22,6 +22,9 @@
   } catch (mcsapi::ColumnStoreError &e) {
     PyErr_SetString(PyExc_RuntimeError, const_cast<char*>(e.what()));
     SWIG_fail;
+  } catch (std::bad_alloc &er) {
+    PyErr_SetString(PyExc_RuntimeError, const_cast<char*>(er.what()));
+    SWIG_fail;
   }
 }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCE_FILES
     mcsapi_driver.cpp
     mcsapi_types.cpp
     mcsapi_bulk.cpp
+    util_debug.cpp
     util_dataconvert.cpp
     util_messaging.cpp
     util_network.cpp

--- a/src/mcsapi_driver.cpp
+++ b/src/mcsapi_driver.cpp
@@ -71,6 +71,12 @@ const char* ColumnStoreDriver::getVersion()
     return version;
 }
 
+void ColumnStoreDriver::setDebug(bool enabled)
+{
+    mcsdebug_set(enabled);
+    mcsdebug("mcsapi debugging enabled, version %s", this->getVersion());
+}
+
 ColumnStoreBulkInsert* ColumnStoreDriver::createBulkInsert(const std::string& db,
     const std::string& table, uint8_t mode, uint16_t pm)
 {

--- a/src/util_debug.cpp
+++ b/src/util_debug.cpp
@@ -1,0 +1,90 @@
+/* Copyright (c) 2017, MariaDB Corporation. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+
+#include "common.h"
+#include "util_debug.h"
+
+#include <stdarg.h>
+
+static bool debugging_enabled = false;
+
+void mcsdebug_set(bool enabled)
+{
+    debugging_enabled = enabled;
+}
+
+void mcsdebug(const char* MSG, ...)
+{
+    if (!debugging_enabled)
+    {
+        return;
+    }
+    struct timeval tv;
+    time_t nowtime;
+    struct tm *nowtm;
+    char tmpdbuf[64], dbuf[64];
+    gettimeofday(&tv, NULL);
+    nowtime = tv.tv_sec;
+    nowtm = localtime(&nowtime);
+    strftime(tmpdbuf, sizeof tmpdbuf, "%H:%M:%S", nowtm);
+    snprintf(dbuf, sizeof dbuf, "%s.%06ld", tmpdbuf, tv.tv_usec);
+    va_list argptr;
+    va_start(argptr, MSG);
+    fprintf(stderr, "[mcsapi][%s] %s:%d ", dbuf,  __FILENAME__, __LINE__);
+    vfprintf(stderr, MSG, argptr);
+    fprintf(stderr, "\n");
+    va_end(argptr);
+}
+
+
+void mcsdebug_hex(const char* DATA, size_t LEN)
+{
+    if (!debugging_enabled)
+    {
+        return;
+    }
+    struct timeval tv;
+    time_t nowtime;
+    struct tm *nowtm;
+    char tmpdbuf[64], dbuf[64];
+    gettimeofday(&tv, NULL);
+    nowtime = tv.tv_sec;
+    nowtm = localtime(&nowtime);
+    strftime(tmpdbuf, sizeof tmpdbuf, "%H:%M:%S", nowtm);
+    snprintf(dbuf, sizeof dbuf, "%s.%06ld", tmpdbuf, tv.tv_usec);
+    size_t hex_it;
+    fprintf(stderr, "[mcsapi][%s] %s:%d packet hex: ", dbuf, __FILENAME__, __LINE__);
+    for (hex_it = 0; hex_it < LEN ; hex_it++)
+    {
+        fprintf(stderr, "%02X ", (unsigned char)DATA[hex_it]);
+    }
+    fprintf(stderr, "\n");
+    fprintf(stderr, "[mcsapi][%s] %s:%d printable packet data: ", dbuf, __FILENAME__, __LINE__);
+    for (hex_it = 0; hex_it < LEN ; hex_it++)
+    {
+        if (((unsigned char)DATA[hex_it] < 0x21) or (((unsigned char)DATA[hex_it] > 0x7e)))
+        {
+            fprintf(stderr, ".");
+        }
+        else
+        {
+            fprintf(stderr, "%c", (unsigned char)DATA[hex_it]);
+        }
+    }
+    fprintf(stderr, "\n");
+}

--- a/src/util_debug.h
+++ b/src/util_debug.h
@@ -18,52 +18,8 @@
 
 #pragma once
 
-#if DEBUG
-#define mcsdebug(MSG, ...) do { \
-    struct timeval tv; \
-    time_t nowtime; \
-    struct tm *nowtm; \
-    char tmpdbuf[64], dbuf[64]; \
-    gettimeofday(&tv, NULL); \
-    nowtime = tv.tv_sec; \
-    nowtm = localtime(&nowtime); \
-    strftime(tmpdbuf, sizeof tmpdbuf, "%H:%M:%S", nowtm); \
-    snprintf(dbuf, sizeof dbuf, "%s.%06ld", tmpdbuf, tv.tv_usec); \
-    fprintf(stderr, "[mcsapi][%s] %s:%d " MSG "\n", dbuf,  __FILENAME__, __LINE__, ##__VA_ARGS__); \
-} while(0)
+void mcsdebug_set(bool enabled);
 
-#define mcsdebug_hex(DATA, LEN) do { \
-    struct timeval tv; \
-    time_t nowtime; \
-    struct tm *nowtm; \
-    char tmpdbuf[64], dbuf[64]; \
-    gettimeofday(&tv, NULL); \
-    nowtime = tv.tv_sec; \
-    nowtm = localtime(&nowtime); \
-    strftime(tmpdbuf, sizeof tmpdbuf, "%H:%M:%S", nowtm); \
-    snprintf(dbuf, sizeof dbuf, "%s.%06ld", tmpdbuf, tv.tv_usec); \
-    size_t hex_it; \
-    fprintf(stderr, "[mcsapi][%s] %s:%d packet hex: ", dbuf, __FILENAME__, __LINE__); \
-    for (hex_it = 0; hex_it < LEN ; hex_it++) \
-    { \
-        fprintf(stderr, "%02X ", (unsigned char)DATA[hex_it]); \
-    } \
-    fprintf(stderr, "\n"); \
-    fprintf(stderr, "[mcsapi][%s] %s:%d printable packet data: ", dbuf, __FILENAME__, __LINE__); \
-    for (hex_it = 0; hex_it < LEN ; hex_it++) \
-    { \
-        if (((unsigned char)DATA[hex_it] < 0x21) or (((unsigned char)DATA[hex_it] > 0x7e))) \
-        { \
-            fprintf(stderr, "."); \
-        } \
-        else \
-        { \
-            fprintf(stderr, "%c", (unsigned char)DATA[hex_it]); \
-        } \
-    } \
-    fprintf(stderr, "\n"); \
-} while(0)
-#else
-#define mcsdebug(MSG, ...)
-#define mcsdebug_hex(DATA, LEN)
-#endif
+void mcsdebug(const char* MSG, ...);
+
+void mcsdebug_hex(const char* DATA, size_t LEN);


### PR DESCRIPTION
- Add debug output to stderr
A new call has been added to ColumnStoreDriver which allows a user to
enable debugging output to stderr. This patch adds it to C++ and
documents it.

- added an additional exception handling for std::bad_alloc in Java and Python