### PR TITLE
MCOL-1321 status information output for setColumn()

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 }
 
 tasks.withType(Test) {
-    def default_lib_path = "${project.projectDir}/../../java"
+    def default_lib_path = "${project.projectDir}"
     systemProperty "java.library.path","${project.hasProperty('java.library.path') ? project.property('java.library.path') : default_lib_path}"
 }
 

--- a/java/javamcsapi.i
+++ b/java/javamcsapi.i
@@ -70,6 +70,19 @@
 }
 
 %module javamcsapi
+
+/* simplyfing enums without initializer */
+%include "enums.swg"
+
+%typemap(javain) enum SWIGTYPE "$javainput.ordinal()"
+%typemap(javaout) enum SWIGTYPE {
+    return $javaclassname.class.getEnumConstants()[$jnicall];
+  }
+%typemap(javabody) enum SWIGTYPE ""
+
+/* MCOL-1321 */
+%include "typemaps.i"
+%apply int *OUTPUT { mcsapi::columnstore_data_convert_status_t* status };
  
 /* swig includes for standard types / exceptions */
 %include <std_except.i>

--- a/java/src/test/java/com/mariadb/columnstore/api/StatusTest.java
+++ b/java/src/test/java/com/mariadb/columnstore/api/StatusTest.java
@@ -1,0 +1,256 @@
+package com.mariadb.columnstore.api;
+
+/*
+ Copyright (c) 2018, MariaDB Corporation. All rights reserved.
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ MA 02110-1301  USA
+*/
+
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class StatusTest extends Common {
+
+    /**
+    / Test that row ingestion works
+    */
+    @Test public void testInserted() {
+        // create test table
+        Connection conn = getConnection();
+        String TABLE_NAME = "java_summary_ins";
+        executeStmt(conn, "DROP TABLE IF EXISTS " + TABLE_NAME);
+        executeStmt(conn, "CREATE TABLE IF NOT EXISTS " + TABLE_NAME + "(a int, b varchar(10)) engine=columnstore");
+        close(conn);
+
+        // simple 1000 row ingestion test
+        ColumnStoreDriver d = new ColumnStoreDriver();
+        ColumnStoreBulkInsert b = d.createBulkInsert(DB_NAME, TABLE_NAME, (short)0, 0);
+        columnstore_data_convert_status_t status;
+        int rows = 1000;
+        int[] s = {-1};
+        try {
+            for (int i=0; i<rows; ++i) {
+                b.setColumn(0, i, s);
+                status = columnstore_data_convert_status_t.values()[s[0]];
+                assertEquals(status, columnstore_data_convert_status_t.CONVERT_STATUS_NONE);
+                b.setColumn(1, "ABC", s);
+                status = columnstore_data_convert_status_t.values()[s[0]];
+                assertEquals(status, columnstore_data_convert_status_t.CONVERT_STATUS_NONE);
+                b.writeRow();
+            }
+            b.commit();
+        } catch (Exception e) {
+            b.rollback();
+            fail("Error during mcsapi write operations: " + e);
+        }
+
+        // verify results
+        conn = getConnection();
+        ColumnStoreSummary summary = b.getSummary();
+        assertEquals(summary.getRowsInsertedCount().intValue(), rows); 
+        
+        Statement stmt = null;
+        ResultSet rs = null;
+        try {
+            stmt = conn.createStatement();
+            rs = stmt.executeQuery("SELECT count(*) cnt FROM " + TABLE_NAME);
+            assertTrue(rs.next());
+            assertEquals(rows,rs.getInt(1));
+        }
+        catch (SQLException e) {
+            fail("Error while validating results: " + e);
+        }
+        finally {
+            close(rs);
+            close(stmt);
+        }
+
+        // drop test table
+        executeStmt(conn, "DROP TABLE IF EXISTS " + TABLE_NAME);
+        close(conn);
+    }
+    
+    /**
+    / Test that saturated works
+    */
+    @Test public void testSaturated() {
+        // create test table
+        Connection conn = getConnection();
+        String TABLE_NAME = "java_summary_sat";
+        executeStmt(conn, "DROP TABLE IF EXISTS " + TABLE_NAME);
+        executeStmt(conn, "CREATE TABLE IF NOT EXISTS " + TABLE_NAME + "(a int, b varchar(10)) engine=columnstore");
+        close(conn);
+
+        // simple row ingestion test
+        ColumnStoreDriver d = new ColumnStoreDriver();
+        ColumnStoreBulkInsert b = d.createBulkInsert(DB_NAME, TABLE_NAME, (short)0, 0);
+        columnstore_data_convert_status_t status;
+        int[] s = {-1};
+        try {
+            b.setColumn(0, Long.MAX_VALUE, s);
+            status = columnstore_data_convert_status_t.values()[s[0]];
+            assertEquals(status, columnstore_data_convert_status_t.CONVERT_STATUS_SATURATED);
+            b.setColumn(1, "ABC", s);
+            status = columnstore_data_convert_status_t.values()[s[0]];
+            assertEquals(status, columnstore_data_convert_status_t.CONVERT_STATUS_NONE);
+            b.writeRow();
+            b.rollback();
+        } catch (Exception e) {
+            fail("Error during mcsapi write operations: " + e);
+        }
+
+        // verify results
+        conn = getConnection();
+        ColumnStoreSummary summary = b.getSummary();
+        assertEquals(summary.getSaturatedCount().intValue(), 1); 
+        
+        Statement stmt = null;
+        ResultSet rs = null;
+        try {
+            stmt = conn.createStatement();
+            rs = stmt.executeQuery("SELECT count(*) cnt FROM " + TABLE_NAME);
+            assertTrue(rs.next());
+            assertEquals(0,rs.getInt(1));
+        }
+        catch (SQLException e) {
+            fail("Error while validating results: " + e);
+        }
+        finally {
+            close(rs);
+            close(stmt);
+        }
+
+        // drop test table
+        executeStmt(conn, "DROP TABLE IF EXISTS " + TABLE_NAME);
+        close(conn);
+    }
+    
+    /**
+    / Test that invalid works
+    */
+    @Test public void testInvalid() {
+        // create test table
+        Connection conn = getConnection();
+        String TABLE_NAME = "java_summary_inv";
+        executeStmt(conn, "DROP TABLE IF EXISTS " + TABLE_NAME);
+        executeStmt(conn, "CREATE TABLE IF NOT EXISTS " + TABLE_NAME + "(a int, b varchar(10)) engine=columnstore");
+        close(conn);
+
+        // simple row ingestion test
+        ColumnStoreDriver d = new ColumnStoreDriver();
+        ColumnStoreBulkInsert b = d.createBulkInsert(DB_NAME, TABLE_NAME, (short)0, 0);
+        columnstore_data_convert_status_t status;
+        int[] s = {-1};
+        try {
+            b.setColumn(0, "abc", s);
+            status = columnstore_data_convert_status_t.values()[s[0]];
+            assertEquals(status, columnstore_data_convert_status_t.CONVERT_STATUS_INVALID);
+            b.setColumn(1, "ABC", s);
+            status = columnstore_data_convert_status_t.values()[s[0]];
+            assertEquals(status, columnstore_data_convert_status_t.CONVERT_STATUS_NONE);
+            b.writeRow();
+            b.rollback();
+        } catch (Exception e) {
+            fail("Error during mcsapi write operations: " + e);
+        }
+
+        // verify results
+        conn = getConnection();
+        ColumnStoreSummary summary = b.getSummary();
+        assertEquals(summary.getInvalidCount().intValue(), 1); 
+        
+        Statement stmt = null;
+        ResultSet rs = null;
+        try {
+            stmt = conn.createStatement();
+            rs = stmt.executeQuery("SELECT count(*) cnt FROM " + TABLE_NAME);
+            assertTrue(rs.next());
+            assertEquals(0,rs.getInt(1));
+        }
+        catch (SQLException e) {
+            fail("Error while validating results: " + e);
+        }
+        finally {
+            close(rs);
+            close(stmt);
+        }
+
+        // drop test table
+        executeStmt(conn, "DROP TABLE IF EXISTS " + TABLE_NAME);
+        close(conn);
+    }
+    
+    /**
+    / Test that truncated works
+    */
+    @Test public void testTruncated() {
+        // create test table
+        Connection conn = getConnection();
+        String TABLE_NAME = "java_summary_trun";
+        executeStmt(conn, "DROP TABLE IF EXISTS " + TABLE_NAME);
+        executeStmt(conn, "CREATE TABLE IF NOT EXISTS " + TABLE_NAME + "(a int, b varchar(10)) engine=columnstore");
+        close(conn);
+
+        // simple row ingestion test
+        ColumnStoreDriver d = new ColumnStoreDriver();
+        ColumnStoreBulkInsert b = d.createBulkInsert(DB_NAME, TABLE_NAME, (short)0, 0);
+        columnstore_data_convert_status_t status;
+        int[] s = {-1};
+        try {
+            b.setColumn(0, 2342, s);
+            status = columnstore_data_convert_status_t.values()[s[0]];
+            assertEquals(status, columnstore_data_convert_status_t.CONVERT_STATUS_NONE);
+            b.setColumn(1, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", s);
+            status = columnstore_data_convert_status_t.values()[s[0]];
+            assertEquals(status, columnstore_data_convert_status_t.CONVERT_STATUS_TRUNCATED);
+            b.writeRow();
+            b.commit();
+        } catch (Exception e) {
+            b.rollback();
+            fail("Error during mcsapi write operations: " + e);
+        }
+
+        // verify results
+        conn = getConnection();
+        ColumnStoreSummary summary = b.getSummary();
+        assertEquals(summary.getTruncationCount().intValue(), 1); 
+        
+        Statement stmt = null;
+        ResultSet rs = null;
+        try {
+            stmt = conn.createStatement();
+            rs = stmt.executeQuery("SELECT count(*) cnt FROM " + TABLE_NAME);
+            assertTrue(rs.next());
+            assertEquals(1,rs.getInt(1));
+        }
+        catch (SQLException e) {
+            fail("Error while validating results: " + e);
+        }
+        finally {
+            close(rs);
+            close(stmt);
+        }
+
+        // drop test table
+        executeStmt(conn, "DROP TABLE IF EXISTS " + TABLE_NAME);
+        close(conn);
+    }
+}

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -86,9 +86,10 @@ IF(PYTHON2_AVAILABLE OR PYTHON3_AVAILABLE)
 
     #Tests
     IF(TEST_RUNNER)
-      add_test(NAME test_basic COMMAND ${PYTHON2_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test/test_basic.py)
-      add_test(NAME test_million_row COMMAND ${PYTHON2_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test/test_million_row.py)
-      add_test(NAME test_exception COMMAND ${PYTHON2_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test/test_exception.py)
+      add_test(NAME test_basic_python COMMAND ${PYTHON2_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test/test_basic.py)
+      add_test(NAME test_million_row_python COMMAND ${PYTHON2_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test/test_million_row.py)
+      add_test(NAME test_exception_python COMMAND ${PYTHON2_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test/test_exception.py)
+      add_test(NAME test_status_python COMMAND ${PYTHON2_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test/test_status.py)
     ENDIF(TEST_RUNNER)
 
     #Install
@@ -110,6 +111,7 @@ IF(PYTHON2_AVAILABLE OR PYTHON3_AVAILABLE)
       add_test(NAME test_basic_python3 COMMAND ${PYTHON3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test/test_basic.py)
       add_test(NAME test_million_row_python3 COMMAND ${PYTHON3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test/test_million_row.py)
       add_test(NAME test_exception_python3 COMMAND ${PYTHON3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test/test_exception.py)
+      add_test(NAME test_status_python3 COMMAND ${PYTHON3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test/test_status.py)
     ENDIF(TEST_RUNNER)
 	
     #Install

--- a/python/pymcsapi.i
+++ b/python/pymcsapi.i
@@ -29,10 +29,15 @@
 }
 
 %module pymcsapi
- 
+
 %{
 #include "libmcsapi/mcsapi.h"
 %}
+
+/* MCOL-1321 */
+%include "typemaps.i"
+%apply int *OUTPUT { mcsapi::columnstore_data_convert_status_t* status };
+/* MCOL-1321 */
 
 /* swig includes for standard types / exceptions */
 %include <std_except.i>
@@ -45,3 +50,4 @@
 %include "libmcsapi/mcsapi_exception.h"
 %include "libmcsapi/mcsapi_driver.h"
 %include "libmcsapi/mcsapi_bulk.h"
+

--- a/python/test/test_basic.py
+++ b/python/test/test_basic.py
@@ -236,9 +236,9 @@ def i1_common(datatype, ch_len):
     d = pymcsapi.ColumnStoreDriver()
     b = d.createBulkInsert(DB_NAME, tablename, 0, 0)
     try:
-        b.setColumn(0,1).setColumn(1, 'ABC').writeRow()
-        b.setColumn(0,2).setColumn(1, 'A').writeRow()
-        b.setColumn(0,3).setColumn(1, 'XYZ').writeRow()
+        b.setColumn(0,1)[0].setColumn(1, 'ABC')[0].writeRow()
+        b.setColumn(0,2)[0].setColumn(1, 'A')[0].writeRow()
+        b.setColumn(0,3)[0].setColumn(1, 'XYZ')[0].writeRow()
         b.commit()
     except RuntimeError as err:
         b.rollback()

--- a/python/test/test_status.py
+++ b/python/test/test_status.py
@@ -1,0 +1,203 @@
+#!/bin/python
+
+# Copyright (c) 2018, MariaDB Corporation. All rights reserved.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301  USA
+import pymcsapi, pytest, datetime
+import mysql.connector as mariadb
+import sys
+from six.moves import range
+
+DB_NAME = 'mcsapi'
+
+if sys.version_info[0] == 3:
+        long = int
+
+def create_db():
+    try:
+        conn = mariadb.connect(user='root')
+        cursor = conn.cursor();
+        cursor.execute("CREATE DATABASE IF NOT EXISTS %s" %(DB_NAME,))
+    except mariadb.Error as err:
+        pytest.fail("Error creating database %s" %(err,))
+    finally:
+        if cursor: cursor.close()
+        if conn: conn.close()
+
+def create_conn():
+    create_db()    
+    try:
+        return mariadb.connect(user='root', database=DB_NAME)
+    except mariadb.Error as err:
+        pytest.fail("Error connecting to mcsapi database %s" %(err,))        
+
+def exec_stmt(conn, stmt):
+    try:
+        cursor = conn.cursor()
+        cursor.execute(stmt)
+    except mariadb.Error as err:
+        pytest.fail("Error executing statement: %s, error: %s" %(stmt,err))
+    finally:
+        if cursor: cursor.close()
+
+def drop_table(conn, tablename):
+    exec_stmt(conn, "DROP TABLE IF EXISTS %s" %(tablename,))
+
+#Test that rows inserted works
+def test_inserted():
+    conn = create_conn()
+    tablename = 'py_summary_ins'
+    rows = 1000
+    drop_table(conn, tablename)
+    exec_stmt(conn, 'create table if not exists %s(a int, b varchar(10)) engine=columnstore' %(tablename,))
+    
+    d = pymcsapi.ColumnStoreDriver()
+    b = d.createBulkInsert(DB_NAME, tablename, 0, 0)
+    try:
+        for i in range(0, rows):
+            bulk, status = b.setColumn(0, i)
+            assert status == pymcsapi.CONVERT_STATUS_NONE
+            bulk, status = b.setColumn(1, 'ABC')
+            assert status == pymcsapi.CONVERT_STATUS_NONE
+            bulk.writeRow()
+        b.commit()
+        
+        s = b.getSummary()
+        assert int(s.getRowsInsertedCount()) == rows
+    except RuntimeError as err:
+        b.rollback()
+        pytest.fail("Error executing status row insertion test: %s" %(err,)) 
+        
+    try:
+        cursor = conn.cursor()
+        cursor.execute('select count(*) cnt from %s' % (tablename,))
+        row = cursor.fetchone()
+        assert row is not None
+        assert row[0] == rows
+    except mariadb.Error as err:
+        pytest.fail("Error executing status row insertion query: %s" %(err,))
+    finally:
+        if cursor: cursor.close()
+    drop_table(conn, tablename)   
+    conn.close()
+
+    
+#Test that saturated works
+def test_saturated():
+    conn = create_conn()
+    tablename = 'py_summary_sat'
+    drop_table(conn, tablename)
+    exec_stmt(conn, 'create table if not exists %s(a int, b varchar(10)) engine=columnstore' %(tablename,))
+    
+    d = pymcsapi.ColumnStoreDriver()
+    b = d.createBulkInsert(DB_NAME, tablename, 0, 0)
+    try:
+        bulk, status = b.setColumn(0, 0xFFFFFFFF)
+        assert status == pymcsapi.CONVERT_STATUS_SATURATED
+        bulk, status = b.setColumn(1, 'ABC')
+        assert status == pymcsapi.CONVERT_STATUS_NONE
+        bulk.writeRow()
+        b.rollback()
+        
+        s = b.getSummary()
+        assert int(s.getSaturatedCount()) == 1
+    except RuntimeError as err:
+        pytest.fail("Error executing status row saturated test: %s" %(err,)) 
+        
+    try:
+        cursor = conn.cursor()
+        cursor.execute('select count(*) cnt from %s' % (tablename,))
+        row = cursor.fetchone()
+        assert row is not None
+        assert row[0] == 0
+    except mariadb.Error as err:
+        pytest.fail("Error executing status row saturated query: %s" %(err,))
+    finally:
+        if cursor: cursor.close()
+    drop_table(conn, tablename)   
+    conn.close()
+
+
+#Test that invalid works
+def test_invalid():
+    conn = create_conn()
+    tablename = 'py_summary_inv'
+    drop_table(conn, tablename)
+    exec_stmt(conn, 'create table if not exists %s(a int, b varchar(10)) engine=columnstore' %(tablename,))
+    
+    d = pymcsapi.ColumnStoreDriver()
+    b = d.createBulkInsert(DB_NAME, tablename, 0, 0)
+    try:
+        bulk, status = b.setColumn(0, 'abc')
+        assert status == pymcsapi.CONVERT_STATUS_INVALID
+        bulk, status = b.setColumn(1, 'ABC')
+        assert status == pymcsapi.CONVERT_STATUS_NONE
+        bulk.writeRow()
+        b.rollback()
+        
+        s = b.getSummary()
+        assert int(s.getInvalidCount()) == 1
+    except RuntimeError as err:
+        pytest.fail("Error executing status row invalid test: %s" %(err,)) 
+        
+    try:
+        cursor = conn.cursor()
+        cursor.execute('select count(*) cnt from %s' % (tablename,))
+        row = cursor.fetchone()
+        assert row is not None
+        assert row[0] == 0
+    except mariadb.Error as err:
+        pytest.fail("Error executing status row invalid query: %s" %(err,))
+    finally:
+        if cursor: cursor.close()
+    drop_table(conn, tablename)   
+    conn.close()
+    
+    
+#Test that saturated works
+def test_truncated():
+    conn = create_conn()
+    tablename = 'py_summary_tru'
+    drop_table(conn, tablename)
+    exec_stmt(conn, 'create table if not exists %s(a int, b varchar(10)) engine=columnstore' %(tablename,))
+    
+    d = pymcsapi.ColumnStoreDriver()
+    b = d.createBulkInsert(DB_NAME, tablename, 0, 0)
+    try:
+        bulk, status = b.setColumn(0, 23)
+        assert status == pymcsapi.CONVERT_STATUS_NONE
+        bulk, status = b.setColumn(1, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')
+        assert status == pymcsapi.CONVERT_STATUS_TRUNCATED
+        bulk.writeRow()
+        b.commit()
+        
+        s = b.getSummary()
+        assert int(s.getTruncationCount()) == 1
+    except RuntimeError as err:
+        pytest.fail("Error executing status row truncation test: %s" %(err,)) 
+        
+    try:
+        cursor = conn.cursor()
+        cursor.execute('select count(*) cnt from %s' % (tablename,))
+        row = cursor.fetchone()
+        assert row is not None
+        assert row[0] == 1
+    except mariadb.Error as err:
+        pytest.fail("Error executing status row truncation query: %s" %(err,))
+    finally:
+        if cursor: cursor.close()
+    drop_table(conn, tablename)   
+    conn.close()


### PR DESCRIPTION
- setColumn() has now two output values: ColumnStoreBulkInsert and status in Java and Python.
- relevant regression tests added
- added a Swig type-map to simplify Java enums without initializes
- includes one usability bugfix for manually executing the Java tests through gradle from the Java directory resulting from MCOL-1261