### PR TITLE
CentOS readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,7 @@ For the main build you need the following, the devtoolset is because GCC5 minimu
 ```shell
 sudo yum install epel-release
 sudo yum install cmake libuv-devel libxml2-devel snappy-devel
-sudo yum install centos-release-scl
-sudo yum install devtoolset-4-gcc*
 sudo yum install java-1.8.0-openjdk java-1.8.0-openjdk-devel swig python-devel python34-devel boost-devel
-scl enable devtoolset-4 bash
 ```
 
 **NOTE** Corresponding to your python3 installation, the correct devel packets need to be installed.


### PR DESCRIPTION
removed devtoolset-4-gcc as its not needed any more