### PR TITLE
MCOL-1195 Clean up TXN when table already locked

### DIFF
--- a/src/mcsapi_bulk.cpp
+++ b/src/mcsapi_bulk.cpp
@@ -432,7 +432,18 @@ void ColumnStoreBulkInsertImpl::connect()
     }
     txnId = commands->brmGetTxnID(sessionId);
     uniqueId = commands->brmGetUniqueId();
-    tblLock = commands->brmGetTableLock(tbl->getOID(), sessionId, txnId, dbRoots);
+    try
+    {
+        tblLock = commands->brmGetTableLock(tbl->getOID(), sessionId, txnId, dbRoots);
+    }
+    catch (ColumnStoreError& cError)
+    {
+        // If we can't get table lock only rollback the txnID and rethrow
+        commands->brmRolledback(txnId);
+        autoRollback = false;
+        transactionClosed = true;
+        throw;
+    }
     for (auto& pmit: pmList)
     {
         commands->weKeepAlive(pmit);


### PR DESCRIPTION
If a table is already locked we need to rollback the transaction ID that
we have already created before throwing the error. Otherwise we are left
with stale transactions with no locks.