### PR TITLE
MCOL-1453 Fix network error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ test/summary
 test/system-catalog
 test/char4
 test/mcol1160
+test/mcol1408
 version.h
 docs/conf.py
 docs/sources.cmake

--- a/src/util_commands.cpp
+++ b/src/util_commands.cpp
@@ -85,7 +85,14 @@ int ColumnStoreCommands::runSoloLoop(ColumnStoreNetwork* connection)
         }
     }
     while ((connection->getStatus() != CON_STATUS_CONNECT_ERROR) &&
+           (connection->getStatus() != CON_STATUS_NET_ERROR) &&
            (connection->getStatus() != CON_STATUS_IDLE));
+
+    if ((connection->getStatus() == CON_STATUS_CONNECT_ERROR) ||
+        (connection->getStatus() == CON_STATUS_NET_ERROR))
+    {
+        throw ColumnStoreNetworkError(connection->getErrMsg());
+    }
 
     return status;
 }
@@ -104,10 +111,16 @@ int ColumnStoreCommands::runLoop()
         for (auto& it: weConnections)
         {
             ColumnStoreNetwork* connection = it.second;
-            if ((connection->getStatus() == CON_STATUS_CONNECT_ERROR) ||
-                (connection->getStatus() == CON_STATUS_IDLE))
+            if (connection->getStatus() == CON_STATUS_IDLE)
             {
                 completed = true;
+            }
+            else if ((connection->getStatus() == CON_STATUS_CONNECT_ERROR) ||
+                     (connection->getStatus() == CON_STATUS_NET_ERROR))
+            {
+                completed = true;
+                throw ColumnStoreNetworkError(connection->getErrMsg());
+                break;
             }
             else
             {

--- a/src/util_network.h
+++ b/src/util_network.h
@@ -56,6 +56,7 @@ public:
     void deleteReadMessage() { delete messageOut; messageOut = nullptr; };
     size_t getDataInBuffer() { return dataInBuffer; };
     void uncompressData(size_t result_length);
+    const std::string& getErrMsg() { return errMsg; };
 
     ~ColumnStoreNetwork();
 private:
@@ -74,6 +75,7 @@ private:
     ColumnStoreMessaging* compressedMessageOut;
     size_t dataInBuffer;
     bool isLocalhost;
+    std::string errMsg;
 
     void writeData(size_t buffer_count);
     void sendCompressedData(ColumnStoreMessaging& message);


### PR DESCRIPTION
Libuv runs the callbacks effectively in a separate thread which means
throwing execptions does nothing. Instead the error status/message
should be logged and thrown when state is checked.