### PR TITLE
MCOL-1612 - Python spark connector fix

### DIFF
--- a/python/test/test_basic.py
+++ b/python/test/test_basic.py
@@ -61,13 +61,17 @@ def all_types_validate(conn, rowid, expected):
     try:
         cursor = conn.cursor()
         cursor.execute(query_all_types, (rowid,))
+        rowsInjected = False
         for (uint64, int64, uint32, int32, uint16, int16, uint8, int8, f, d, ch4, vch30, dt, dtm, dc, tx) in cursor:
+            rowsInjected = True
             rowStr = "{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}".format(uint64, int64, uint32, int32, uint16, int16, uint8, int8, f,d, ch4, vch30, dt, dtm, dc, tx)
             assert rowStr == expected
     except mariadb.Error as err:
         pytest.fail("Error executing query: %s, error: %s" %(query_all_types,err))
     finally:
         if cursor: cursor.close()
+    if not rowsInjected:
+        pytest.fail("nothing injected into columnstore")
    
 #
 # Test all column types and min / max range values

--- a/spark-connector/python/columnStoreExporter.py
+++ b/spark-connector/python/columnStoreExporter.py
@@ -81,7 +81,7 @@ def export(database, table, df, configuration=None):
     except Exception as e:
         bulkInsert.rollback()
         print("An exception occured. The bulk insert was rolled back.")
-        print("row: %d, ingest type: %s, ingest value: %s" % (row[columnId], type(row[columnId]), row[columnId]))
+        print("row: %s, ingest type: %s, ingest value: %s" % (row[columnId], type(row[columnId]), row[columnId]))
         print(type(e), str(e))
        
     #print a short summary of the insertion process

--- a/spark-connector/python/columnStoreExporter.py
+++ b/spark-connector/python/columnStoreExporter.py
@@ -43,7 +43,7 @@ def export(database, table, df, configuration=None):
         for row in rows:
             for columnId in range(0, len(row)):
                 if columnId < dbTableColumnCount:
-                    if row.get(columnId) is None:
+                    if row[columnId] is None:
                         if dbTable.getColumn(columnId).isNullable():
                             bulkInsert.setNull(columnId)
                         else:
@@ -80,9 +80,9 @@ def export(database, table, df, configuration=None):
         bulkInsert.commit()
     except Exception as e:
         bulkInsert.rollback()
-        print(row[columnId], type(row[columnId]))
-        print(type(e))
-        print(e)
+        print("An exception occured. The bulk insert was rolled back.")
+        print("row: %d, ingest type: %s, ingest value: %s" % (row[columnId], type(row[columnId]), row[columnId]))
+        print(type(e), str(e))
        
     #print a short summary of the insertion process
     summary = bulkInsert.getSummary()

--- a/spark-connector/python/test/test_column_store_SQL_generation.py
+++ b/spark-connector/python/test/test_column_store_SQL_generation.py
@@ -84,7 +84,9 @@ def verifyAllTypes(conn, table, rowid, expected):
     try:
         cursor = conn.cursor()
         cursor.execute(query_all_types)
+        rowsInjected = False
         for (uint64, int64, uint32, int32, uint16, int16, uint8, int8_rw, f, d, ch4, vch30, dt, dtm, dc, tx, bit_rw, mathInt, dc2) in cursor:
+            rowsInjected = True
             rowStr = "{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}".format(uint64, int64, uint32, int32, uint16, int16, uint8, int8_rw, f, d, ch4, vch30, dt, dtm, dc, tx, bit_rw, mathInt, dc2)
             assert rowStr == expected
     except mariadb.Error as err:
@@ -95,6 +97,8 @@ def verifyAllTypes(conn, table, rowid, expected):
         pytest.fail("Error executing query: %s, error: %s" %(verifyAllTypes,e))
     finally:
         if cursor: cursor.close()
+    if not rowsInjected:
+        pytest.fail("no data injected into columnstore")
 
 #test the sql generation by repeating the test_all case with the generated table
 def test_sql_generation():

--- a/spark-connector/python/test/test_column_store_exporter.py
+++ b/spark-connector/python/test/test_column_store_exporter.py
@@ -21,7 +21,6 @@ import mysql.connector as mariadb
 
 #verify that the dataframe was stored correctly
 def verifyAllTypes(conn, table, rowid, expected):
-    print("verifyAllTypes called")
     query_all_types = "select uint64, int64, uint32, int32, uint16, int16, uint8, `int8`, f, d, ch4, vch30, dt, dtm, dc, tx, bit, mathInt, dc2 from %s where uint64 = %s" % (table, rowid)
     try:
         cursor = conn.cursor()
@@ -30,16 +29,12 @@ def verifyAllTypes(conn, table, rowid, expected):
         for (uint64, int64, uint32, int32, uint16, int16, uint8, int8, f, d, ch4, vch30, dt, dtm, dc, tx, bit, mathInt, dc2) in cursor:
             resultsFound = True
             rowStr = "{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}".format(uint64, int64, uint32, int32, uint16, int16, uint8, int8, f, d, ch4, vch30, dt, dtm, dc, tx, bit, mathInt, dc2)
-            print("rowStr: %s expected: %s" % (rowStr, expected))
             assert rowStr == expected
     except mariadb.Error as err:
-        print("Error executing query")
         pytest.fail("Error executing query: %s, error: %s" %(verifyAllTypes,err))
     except AssertionError as e:
-        print("Injected doesn't match expetations")
         pytest.fail("%s\nInjected doesn't match expetations.\nexpected: %s\nactual:   %s" % (e,expected,rowStr))
     finally:
-        print("finally")
         if cursor: cursor.close()
     if not resultsFound:
         pytest.fail("no data was injected into columnstore")

--- a/spark-connector/python/test/test_column_store_exporter.py
+++ b/spark-connector/python/test/test_column_store_exporter.py
@@ -21,20 +21,28 @@ import mysql.connector as mariadb
 
 #verify that the dataframe was stored correctly
 def verifyAllTypes(conn, table, rowid, expected):
+    print("verifyAllTypes called")
     query_all_types = "select uint64, int64, uint32, int32, uint16, int16, uint8, `int8`, f, d, ch4, vch30, dt, dtm, dc, tx, bit, mathInt, dc2 from %s where uint64 = %s" % (table, rowid)
     try:
         cursor = conn.cursor()
         cursor.execute(query_all_types)
+        resultsFound = False
         for (uint64, int64, uint32, int32, uint16, int16, uint8, int8, f, d, ch4, vch30, dt, dtm, dc, tx, bit, mathInt, dc2) in cursor:
+            resultsFound = True
             rowStr = "{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}".format(uint64, int64, uint32, int32, uint16, int16, uint8, int8, f, d, ch4, vch30, dt, dtm, dc, tx, bit, mathInt, dc2)
+            print("rowStr: %s expected: %s" % (rowStr, expected))
             assert rowStr == expected
     except mariadb.Error as err:
+        print("Error executing query")
         pytest.fail("Error executing query: %s, error: %s" %(verifyAllTypes,err))
     except AssertionError as e:
+        print("Injected doesn't match expetations")
         pytest.fail("%s\nInjected doesn't match expetations.\nexpected: %s\nactual:   %s" % (e,expected,rowStr))
     finally:
+        print("finally")
         if cursor: cursor.close()
-
+    if not resultsFound:
+        pytest.fail("no data was injected into columnstore")
 
 def test_all_types():
     #Datatype settings
@@ -129,7 +137,7 @@ def test_all_types():
         else:
             verifyAllTypes(connection, table, 0, "0, -9223372036854775806, 0, -2147483646, 0, -32766, 0, -126, 1.234, 2.34567, A, B, 1000-01-01, 1000-01-01 00:00:00, -123, C, 0, 18446744073709551613, 100000000.999999999")
         verifyAllTypes(connection, table, 9223372036854775807, "9223372036854775807, 9223372036854775807, 4294967293, 2147483647, 65533, 32767, 253, 127, 1.234, 2.34567, ZYXW, 012345678901234567890123456789, 9999-12-31, 9999-12-31 23:59:59, 123, 012345678901234567890123456789, 1, 2342, 23.420000000")
-        verifyAllTypes(connection, table, 42, "42, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null")
+        verifyAllTypes(connection, table, 42, "42, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None")
     
     #drop the test tables
     cursor = connection.cursor()

--- a/spark-connector/python/test/test_column_store_exporter.sh
+++ b/spark-connector/python/test/test_column_store_exporter.sh
@@ -2,7 +2,7 @@
 
 if [ "$#" -ne 2 ]; then
     echo "$0 python_executable_path pyspark_driver_python"
-	exit 2
+	exit 666
 fi
 
 SCRIPT=$(readlink -f "$0")


### PR DESCRIPTION
Fixes an error in the python spark connector and makes it usable again.
Also adjusts the tests so that this error will be discovered through our regression test suite.