### PR TITLE
MCOL-1566 - pymcsapi & javamcsapi documentation out of source fix - CentOS LaTeX build fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ sudo make install
 
 ### CentOS 7
 
-For the main build you need the following, the devtoolset is because GCC5 minimum is required for full C++11 support:
+For the main build you need the following:
 
 ```shell
 sudo yum install epel-release
@@ -95,9 +95,22 @@ sudo yum install java-1.8.0-openjdk java-1.8.0-openjdk-devel swig python-devel p
 For the documentation:
 
 ```shell
-sudo yum install python34 texlive-scheme-full latexmk python34-pip
+sudo yum install python34 python34-pip perl
 sudo pip3 install -U Sphinx
 sudo pip3 install javasphinx
+# As CentOS's LaTeX is broken we install texlive from ctan
+curl -L -O http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+tar -xf install-tl-unx.tar.gz
+cd install-tl-*
+sudo ./install-tl << EOF
+O
+L
+
+
+
+R
+I
+EOF
 ```
 
 For the test suite:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ sudo apt-get install cmake g++ libuv1-dev libxml2-dev libsnappy-dev pkg-config s
 For the documentation:
 
 ```shell
-sudo apt-get install python3 python-pip3 texlive-latex-recommended texlive-latex-extra latexmk
+sudo apt-get install python3 python3-pip texlive-latex-recommended texlive-latex-extra latexmk
 pip3 install -U Sphinx
 pip3 install javasphinx
 ```
@@ -64,7 +64,7 @@ sudo update-alternatives --config java
 For the documentation:
 
 ```shell
-sudo apt-get install python3 python-pip3 texlive-latex-recommended texlive-latex-extra latexmk
+sudo apt-get install python3 python3-pip texlive-latex-recommended texlive-latex-extra latexmk
 pip3 install -U Sphinx
 pip3 install javasphinx
 ```
@@ -96,8 +96,8 @@ For the documentation:
 
 ```shell
 sudo yum install python34 texlive-scheme-full latexmk python34-pip
-pip3 install -U Sphinx
-pip3 install javasphinx
+sudo pip3 install -U Sphinx
+sudo pip3 install javasphinx
 ```
 
 For the test suite:

--- a/java/docs/CMakeLists.txt
+++ b/java/docs/CMakeLists.txt
@@ -87,7 +87,7 @@ if(GENERATE_DOC)
 	-c "${BINARY_BUILD_DIR}"
 	-d "${SPHINX_CACHE_DIR}"
     "${PDF_SOURCES_DIR}"
-	"${SPHINX_PDF_DIR}"
+      "${SPHINX_PDF_DIR}"
       COMMENT "Building Java PDF documentation with Sphinx"
     )
     add_custom_command(TARGET doc_pdf_JAVAMCSAPI POST_BUILD

--- a/java/docs/sources.cmake.in
+++ b/java/docs/sources.cmake.in
@@ -30,7 +30,7 @@ file(GLOB SOURCES_2
 foreach(source ${SOURCES_2})
   configure_file(
     "@CMAKE_SOURCE_DIR@/example/${source}"
-    "@CMAKE_CURRENT_SOURCE_DIR@/example/${source}"
+    "@SOURCES_DIR@/../example/${source}"
     COPYONLY
   )
 endforeach(source)

--- a/python/docs/sources.cmake.in
+++ b/python/docs/sources.cmake.in
@@ -30,7 +30,7 @@ file(GLOB SOURCES_2
 foreach(source ${SOURCES_2})
   configure_file(
     "@CMAKE_SOURCE_DIR@/example/${source}"
-    "@CMAKE_CURRENT_SOURCE_DIR@/example/${source}"
+    "@SOURCES_DIR@/../example/${source}"
     COPYONLY
   )
 endforeach(source)


### PR DESCRIPTION
- fixed the pymcsapi and javamcsapi documentation for out of source builds
- changed the build instructions in Readme.md to install LaTeX on CentOS from ctan.org instead of CentOS's packet manager