### PR TITLE
MCOL-1720 Fix DateTime format failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,17 +16,6 @@ if(NOT COMPILER_SUPPORTS_CXX11)
     message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
 endif()
 
-CHECK_CXX_SOURCE_COMPILES("
-#include <time.h>
-#include <sstream>
-#include <iomanip>
-int main(int argc, char** argv){
-    tm time = {};
-    std::istringstream ss(\"01-01-01 00:00:00\");
-    ss >> std::get_time(&time, \"%Y\");
-    return 0;
-}" HAVE_GET_TIME)
-
 include(cmake/version.cmake)
 
 # use, i.e. don't skip the full RPATH for the build tree

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,10 +14,6 @@ ENDIF(WIN32)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILDING_MCSAPI")
 
-if (HAVE_GET_TIME)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_GET_TIME=1")
-endif(HAVE_GET_TIME)
-
 set(SOURCE_FILES
     mcsapi_driver.cpp
     mcsapi_types.cpp

--- a/src/mcsapi_types.cpp
+++ b/src/mcsapi_types.cpp
@@ -86,16 +86,7 @@ bool ColumnStoreDateTime::set(tm& time)
 bool ColumnStoreDateTime::set(const std::string& dateTime, const std::string& format)
 {
     tm time = tm();
-#ifdef HAVE_GET_TIME
-    std::istringstream ss(dateTime);
-    ss >> std::get_time(&time, format.c_str());
-    if (ss.fail())
-    {
-        return false;
-    }
-#else
     strptime(dateTime.c_str(), format.c_str(), &time);
-#endif
     return set(time);
 }
 

--- a/src/mcsapi_types.cpp
+++ b/src/mcsapi_types.cpp
@@ -86,7 +86,18 @@ bool ColumnStoreDateTime::set(tm& time)
 bool ColumnStoreDateTime::set(const std::string& dateTime, const std::string& format)
 {
     tm time = tm();
+    // Windows doesn't support strptime but Linux's std::get_time() is
+    // inconsistent across different glibc versions
+#ifdef _WIN32
+    std::istringstream ss(dateTime);
+    ss >> std::get_time(&time, format.c_str());
+    if (ss.fail())
+    {
+        return false;
+    }
+#else
     strptime(dateTime.c_str(), format.c_str(), &time);
+#endif
     return set(time);
 }
 

--- a/test/dataconvert-datetime.cpp
+++ b/test/dataconvert-datetime.cpp
@@ -52,12 +52,22 @@ class TestEnvironment : public ::testing::Environment {
         FAIL() << "Could not select DB: " << mysql_error(my_con);
     if (mysql_query(my_con, "DROP TABLE IF EXISTS dataconvertdatetime"))
         FAIL() << "Could not drop existing table: " << mysql_error(my_con);
+    if (mysql_query(my_con, "DROP TABLE IF EXISTS dataconvertdatetime2"))
+        FAIL() << "Could not drop existing table: " << mysql_error(my_con);
     if (mysql_query(my_con, "CREATE TABLE IF NOT EXISTS dataconvertdatetime (a int, b varchar(50), c date, d datetime) engine=columnstore"))
+        FAIL() << "Could not create table: " << mysql_error(my_con);
+    if (mysql_query(my_con, "CREATE TABLE IF NOT EXISTS dataconvertdatetime2 (d datetime) engine=columnstore"))
         FAIL() << "Could not create table: " << mysql_error(my_con);
   }
   // Override this to define how to tear down the environment.
   virtual void TearDown()
   {
+    if (mysql_query(my_con, "DROP TABLE dataconvertdatetime"))
+        FAIL() << "Could not drop table: " << mysql_error(my_con);
+
+    if (mysql_query(my_con, "DROP TABLE dataconvertdatetime2"))
+        FAIL() << "Could not drop table: " << mysql_error(my_con);
+
     if (my_con)
     {
         mysql_close(my_con);
@@ -65,6 +75,32 @@ class TestEnvironment : public ::testing::Environment {
   }
 };
 
+/* Test strptime compatibility */
+TEST(DataConvertDateTime, DataConvertFormats)
+{
+    //test data
+    std::string datetimes[] = { "6 Dec 2001 12:33:45" , "06.12.2001 12:33:46" , "2001-12-06 12 33 47"};
+    std::string formats[] = { "%d %b %Y %H:%M:%S" , "%d.%m.%Y %H:%M:%S" , "%Y-%m-%d %H %M %S" };
+
+    mcsapi::ColumnStoreDriver* driver = nullptr;
+    mcsapi::ColumnStoreBulkInsert* bulk = nullptr;
+    try {
+        driver = new mcsapi::ColumnStoreDriver();
+        bulk = driver->createBulkInsert("mcsapi", "dataconvertdatetime2", 0, 0);
+        for (int i=0; i<(sizeof(datetimes)/sizeof(datetimes[0])) && i<(sizeof(formats)/sizeof(formats[0])); i++){
+            std::cout << "trying to inject datetime '" << datetimes[i] << "' with format '" << formats[i] << "'" << std::endl;
+            mcsapi::ColumnStoreDateTime dt = mcsapi::ColumnStoreDateTime(datetimes[i], formats[i]);
+            bulk->setColumn(0,dt);
+            bulk->writeRow();
+            std::cout << "injection successfull" << std::endl;
+        }
+        bulk->commit();
+    } catch (std::exception &e) {
+        FAIL() << "Error caught: " << e.what() << std::endl;
+    }
+    delete bulk;
+    delete driver;
+}
 
 /* Test that dataconvert from datetime works */
 TEST(DataConvertDateTime, DataConvertDateTime)
@@ -154,8 +190,6 @@ TEST(DataConvertDateTime, DataConvertDateTime)
     ASSERT_STREQ(row[2], "2017-09-30");
     ASSERT_STREQ(row[3], "2017-09-30 23:59:59");
     mysql_free_result(result);
-    if (mysql_query(my_con, "DROP TABLE dataconvertdatetime"))
-        FAIL() << "Could not drop table: " << mysql_error(my_con);
     delete bulk;
     delete driver;
 }


### PR DESCRIPTION
Internally we used std::get_time() where we could to do date/time
conversions. Unfortunately it appears every version of glibc has
different behaviour quirks with that function so switching to strptime()
instead.