### PR TITLE
MCOL-1671 - Added an option to include the shared library directory t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 cmake/cpack_windows/*.wxs
 cmake/cpack_windows/*.wxs.cf
 cmake/cpack_windows/product_fragment.patch
+cmake/cpack_windows/features.patch
 java/test/columnstore-*
 .pytest_cache
 .gradle

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,11 @@ if (WIN32)
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpack_windows/product_fragment.patch"
         IMMEDIATE @ONLY)
     LIST(APPEND WIX_PATCH_FILES "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpack_windows/product_fragment.patch")
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpack_windows/features.patch.in"
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpack_windows/features.patch"
+        IMMEDIATE @ONLY)
+    LIST(APPEND WIX_PATCH_FILES "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpack_windows/features.patch")
     SET(CPACK_WIX_PATCH_FILE ${WIX_PATCH_FILES})
     SET(CPACK_PACKAGE_NAME "MariaDB ColumnStore Bulk Write SDK")
     set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "MariaDB ColumnStore Bulk Write SDK")

--- a/cmake/cpack_windows/features.patch.in
+++ b/cmake/cpack_windows/features.patch.in
@@ -1,0 +1,9 @@
+<CPackWiXPatch>
+  <!--Set PATH entry for mcsapi-->
+  <CPackWiXFragment Id="#PRODUCTFEATURE">
+    <Feature Id="McsApiPATH" Title="Add libs to PATH" Description="Set a PATH entry for mcsapi's and javamcsapi's shared libraries so that they can be used directly from Java without setting java.library.path">
+        <ComponentRef Id="McsApiPATH" />
+    </Feature>
+  </CPackWiXFragment>
+</CPackWiXPatch>
+

--- a/cmake/cpack_windows/product_fragment.patch.in
+++ b/cmake/cpack_windows/product_fragment.patch.in
@@ -22,7 +22,13 @@
         <MergeRef Id="VCRedist141"/>
         <Condition Level="0">VCREDIST140INSTALLED_X64 OR VCREDIST140INSTALLED2_X64</Condition>
     </Feature>
-	<!--Activate other wix features from separate wxs files-->
+    <!--Set PATH entry for mcsapi-->
+    <DirectoryRef Id="TARGETDIR">
+      <Component Id="McsApiPATH" Guid="2d84819d-5f06-4aa3-9551-49ce85e46919">
+        <Environment Id="mcsPATH" Name="PATH" Value="[CM_DP_libs.lib]" Permanent="no" Part="last" Action="set" System="yes" />
+      </Component>
+    </DirectoryRef>
+    <!--Activate other wix features from separate wxs files-->
     @PYTHON_2_FEATRUE_REF@
     @PYTHON_3_FEATRUE_REF@
   </CPackWiXFragment>

--- a/cmake/cpack_windows/python2.wxs.in
+++ b/cmake/cpack_windows/python2.wxs.in
@@ -39,6 +39,7 @@
             </Component>
             <Component Id='python2columnStoreExporter' Guid='a8f2464a-7586-4359-8f42-4899a469b714'>
               <File Id='python2columnStoreExporter' Source='@PYTHON2_COLUMNSTORE_EXPORTER@' KeyPath='yes'/>
+              <RemoveFile Id='python2columnStoreExporterPyc' On='uninstall' Name='columnStoreExporter.pyc' />
             </Component>
         </Directory>
       </Directory>

--- a/java/docs/compiling.rst
+++ b/java/docs/compiling.rst
@@ -51,7 +51,7 @@ Windows 10 (x64)
    javac -classpath ".;%mcsapiInstallDir%\lib\java\javamcsapi-1.1.7.jar" Basic_bulk_insert.java
    java -classpath ".;%mcsapiInstallDir%\lib\java\javamcsapi-1.1.7.jar" -Djava.library.path="%mcsapiInstallDir%\lib" Basic_bulk_insert
 
-The variable ``%mcsapiInstallDir%`` represents the base installation directory of the Bulk Write SDK. (e.g. ``C:\\Program Files\\MariaDB\\ColumnStore Bulk Write SDK``)
+The variable ``%mcsapiInstallDir%`` represents the base installation directory of the Bulk Write SDK. (e.g. ``C:\Program Files\MariaDB\ColumnStore Bulk Write SDK``)
 
 If you don't want to change the ``java.library.path`` you can copy javamcapi's DLLs ``libiconv.dll``, ``libuv.dll``, ``libxml2.dll``, ``mcsapi.dll`` and ``javamcsapi.dll`` from ``%mcsapiInstallDir%\lib`` to the directory of the Java class to execute.  
 Another option is to just add ``%mcsapiInstallDir%\lib`` to your ``PATH`` environment variable, which is the default setting when you install the Bulk Write SDK.

--- a/java/docs/compiling.rst
+++ b/java/docs/compiling.rst
@@ -48,9 +48,10 @@ Windows 10 (x64)
 
 .. code-block:: console
 
-   javac -classpath ".;%mcsapiInstallDir%\lib\java\javamcsapi-1.1.6.jar" Basic_bulk_insert.java
-   java -classpath ".;%mcsapiInstallDir%\lib\java\javamcsapi-1.1.6.jar" -Djava.library.path="%mcsapiInstallDir%\lib" Basic_bulk_insert
+   javac -classpath ".;%mcsapiInstallDir%\lib\java\javamcsapi-1.1.7.jar" Basic_bulk_insert.java
+   java -classpath ".;%mcsapiInstallDir%\lib\java\javamcsapi-1.1.7.jar" -Djava.library.path="%mcsapiInstallDir%\lib" Basic_bulk_insert
 
-The variable ``%mcsapiInstallDir%`` represents the base installation directory of the Bulk Write SDK. (e.g. C:\\Program Files\\MariaDB\\ColumnStore Bulk Write SDK)
+The variable ``%mcsapiInstallDir%`` represents the base installation directory of the Bulk Write SDK. (e.g. ``C:\\Program Files\\MariaDB\\ColumnStore Bulk Write SDK``)
 
-If you don't want to change the ``java.library.path`` you can copy javamcapi's DLLs ``libiconv.dll``, ``libuv.dll``, ``libxml2.dll``, ``mcsapi.dll`` and ``javamcsapi.dll`` from ``%mcsapiInstallDir%\lib`` to the directory of the Java class to execute.
+If you don't want to change the ``java.library.path`` you can copy javamcapi's DLLs ``libiconv.dll``, ``libuv.dll``, ``libxml2.dll``, ``mcsapi.dll`` and ``javamcsapi.dll`` from ``%mcsapiInstallDir%\lib`` to the directory of the Java class to execute.  
+Another option is to just add ``%mcsapiInstallDir%\lib`` to your ``PATH`` environment variable, which is the default setting when you install the Bulk Write SDK.


### PR DESCRIPTION
…o the Windows System PATH during installation to don't have to set java.library.path while executing Java programs that use javamcsapi.

Regression test suite succeeded on Win 10 and CentOS 7.