### PR TITLE
Improve the debugging output

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,21 +3,23 @@ Version History
 
 This is a version history of C++ API interface changes. It does not include internal fixes and changes.
 
-+---------+---------------------------------------------------------------------------------------------------------------------------------------+
-| Version | Changes                                                                                                                               |
-+=========+=======================================================================================================================================+
-| 1.2.0   | - Add support for TIME datatype with :cpp:class:`ColumnStoreTime`                                                                     |
-+---------+---------------------------------------------------------------------------------------------------------------------------------------+
-| 1.1.6   | - Windows support added (Alpha)                                                                                                       |
-+---------+---------------------------------------------------------------------------------------------------------------------------------------+
-| 1.1.4   | - Make :cpp:func:`ColumnStoreSystemCatalog::getTable` and :cpp:func:`ColumnStoreSystemCatalogTable::getColumn` case insensitive       |
-|         | - Add :cpp:func:`ColumnStoreDriver::setDebug` to enable debugging output to stderr                                                    |
-+---------+---------------------------------------------------------------------------------------------------------------------------------------+
-| 1.1.1   | - Add :cpp:func:`ColumnStoreBulkInsert::isActive`                                                                                     |
-|         | - Make :cpp:func:`ColumnStoreBulkInsert::rollback` fail without error                                                                 |
-|         | - Add :cpp:func:`ColumnStoreBulkInsert::resetRow`                                                                                     |
-|         | - :cpp:func:`ColumnStoreDateTime::ColumnStoreDateTime` now uses uint32_t for every parameter                                          |
-|         | - :cpp:class:`ColumnStoreSystemCatalog` now uses const for the sub-class strings                                                      |
-+---------+---------------------------------------------------------------------------------------------------------------------------------------+
-| 1.1.0β  | - First beta release                                                                                                                  |
-+---------+---------------------------------------------------------------------------------------------------------------------------------------+
++---------+---------------------------------------------------------------------------------------------------------------------------------+
+| Version | Changes                                                                                                                         |
++=========+=================================================================================================================================+
+| 1.2.1   | - :cpp:func:`ColumnStoreDriver::setDebug` is now an integer setting for debug level instead of boolean                          |
++---------+---------------------------------------------------------------------------------------------------------------------------------+
+| 1.2.0   | - Add support for TIME datatype with :cpp:class:`ColumnStoreTime`                                                               |
++---------+---------------------------------------------------------------------------------------------------------------------------------+
+| 1.1.6   | - Windows support added (Alpha)                                                                                                 |
++---------+---------------------------------------------------------------------------------------------------------------------------------+
+| 1.1.4   | - Make :cpp:func:`ColumnStoreSystemCatalog::getTable` and :cpp:func:`ColumnStoreSystemCatalogTable::getColumn` case insensitive |
+|         | - Add :cpp:func:`ColumnStoreDriver::setDebug` to enable debugging output to stderr                                              |
++---------+---------------------------------------------------------------------------------------------------------------------------------+
+| 1.1.1   | - Add :cpp:func:`ColumnStoreBulkInsert::isActive`                                                                               |
+|         | - Make :cpp:func:`ColumnStoreBulkInsert::rollback` fail without error                                                           |
+|         | - Add :cpp:func:`ColumnStoreBulkInsert::resetRow`                                                                               |
+|         | - :cpp:func:`ColumnStoreDateTime::ColumnStoreDateTime` now uses uint32_t for every parameter                                    |
+|         | - :cpp:class:`ColumnStoreSystemCatalog` now uses const for the sub-class strings                                                |
++---------+---------------------------------------------------------------------------------------------------------------------------------+
+| 1.1.0β  | - First beta release                                                                                                            |
++---------+---------------------------------------------------------------------------------------------------------------------------------+

--- a/docs/reference/driver.rst
+++ b/docs/reference/driver.rst
@@ -136,14 +136,18 @@ Example
 setDebug()
 ----------
 
-.. cpp:function:: void ColumnStoreDriver::setDebug(bool enabled)
+.. cpp:function:: void ColumnStoreDriver::setDebug(uint8_t level)
 
-   Enables/disables verbose debugging output which is sent to stderr upon execution.
+   Enables/disables verbose debugging output which is sent to stderr upon execution. Levels are as follows:
+
+   * ``0`` - Off
+   * ``1`` - Show messages and binary packets truncated at 1000 bytes
+   * ``2`` - Show full messages, full length binary packets and ASCII translations
 
    .. note::
       This is a global setting which will apply to all instances of all of the API's classes after it is set until it is turned off.
 
-   :param enabled: Set to ``true`` to enable and ``false`` to disable.
+   :param level: Set to the log level required, ``0`` = off.
 
 Example
 ^^^^^^^

--- a/libmcsapi/mcsapi_driver.h
+++ b/libmcsapi/mcsapi_driver.h
@@ -31,7 +31,7 @@ public:
     ~ColumnStoreDriver();
 
     const char* getVersion();
-    void setDebug(bool enabled);
+    void setDebug(uint8_t level);
     ColumnStoreBulkInsert* createBulkInsert(const std::string& db,
             const std::string& table, uint8_t mode, uint16_t pm);
     ColumnStoreSystemCatalog& getSystemCatalog();

--- a/src/mcsapi_driver.cpp
+++ b/src/mcsapi_driver.cpp
@@ -71,10 +71,10 @@ const char* ColumnStoreDriver::getVersion()
     return version;
 }
 
-void ColumnStoreDriver::setDebug(bool enabled)
+void ColumnStoreDriver::setDebug(uint8_t level)
 {
-    mcsdebug_set(enabled);
-    mcsdebug("mcsapi debugging enabled, version %s", this->getVersion());
+    mcsdebug_set(level);
+    mcsdebug("mcsapi debugging set to level %d, version %s", level, this->getVersion());
 }
 
 ColumnStoreBulkInsert* ColumnStoreDriver::createBulkInsert(const std::string& db,

--- a/src/util_dataconvert.cpp
+++ b/src/util_dataconvert.cpp
@@ -1065,14 +1065,14 @@ columnstore_data_convert_status_t ColumnStoreDataConvert::convert(ColumnStoreSys
             {
                 val64 = stoll(fromValue);
             }
-            catch (std::invalid_argument)
+            catch (std::invalid_argument&)
             {
                 status = CONVERT_STATUS_INVALID;
                 val8 = 0;
                 cont->setData(val8);
                 break;
             }
-            catch (std::out_of_range)
+            catch (std::out_of_range&)
             {
                 status = CONVERT_STATUS_INVALID;
                 val8 = 0;
@@ -1098,14 +1098,14 @@ columnstore_data_convert_status_t ColumnStoreDataConvert::convert(ColumnStoreSys
             {
                 val64 = stoll(fromValue);
             }
-            catch (std::invalid_argument)
+            catch (std::invalid_argument&)
             {
                 status = CONVERT_STATUS_INVALID;
                 val8 = 0;
                 cont->setData(val8);
                 break;
             }
-            catch (std::out_of_range)
+            catch (std::out_of_range&)
             {
                 status = CONVERT_STATUS_INVALID;
                 val8 = 0;
@@ -1137,14 +1137,14 @@ columnstore_data_convert_status_t ColumnStoreDataConvert::convert(ColumnStoreSys
             {
                 val64 = stoll(fromValue);
             }
-            catch (std::invalid_argument)
+            catch (std::invalid_argument&)
             {
                 status = CONVERT_STATUS_INVALID;
                 val16 = 0;
                 cont->setData(val16);
                 break;
             }
-            catch (std::out_of_range)
+            catch (std::out_of_range&)
             {
                 status = CONVERT_STATUS_INVALID;
                 val16 = 0;
@@ -1177,14 +1177,14 @@ columnstore_data_convert_status_t ColumnStoreDataConvert::convert(ColumnStoreSys
             {
                 valD = stod(fromValue);
             }
-            catch (std::invalid_argument)
+            catch (std::invalid_argument&)
             {
                 status = CONVERT_STATUS_INVALID;
                 val64 = 0;
                 cont->setData(val64);
                 break;
             }
-            catch (std::out_of_range)
+            catch (std::out_of_range&)
             {
                 status = CONVERT_STATUS_INVALID;
                 val64 = 0;
@@ -1259,14 +1259,14 @@ columnstore_data_convert_status_t ColumnStoreDataConvert::convert(ColumnStoreSys
             {
                 val64 = stoll(fromValue);
             }
-            catch (std::invalid_argument)
+            catch (std::invalid_argument&)
             {
                 status = CONVERT_STATUS_INVALID;
                 val32 = 0;
                 cont->setData(val32);
                 break;
             }
-            catch (std::out_of_range)
+            catch (std::out_of_range&)
             {
                 status = CONVERT_STATUS_INVALID;
                 val32 = 0;
@@ -1299,14 +1299,14 @@ columnstore_data_convert_status_t ColumnStoreDataConvert::convert(ColumnStoreSys
             {
                 val64 = stoll(fromValue);
             }
-            catch (std::invalid_argument)
+            catch (std::invalid_argument&)
             {
                 status = CONVERT_STATUS_INVALID;
                 val32 = 0;
                 cont->setData(val32);
                 break;
             }
-            catch (std::out_of_range)
+            catch (std::out_of_range&)
             {
                 status = CONVERT_STATUS_INVALID;
                 val32 = 0;
@@ -1338,14 +1338,14 @@ columnstore_data_convert_status_t ColumnStoreDataConvert::convert(ColumnStoreSys
             {
                 valF = stof(fromValue);
             }
-            catch (std::invalid_argument)
+            catch (std::invalid_argument&)
             {
                 status = CONVERT_STATUS_INVALID;
                 val32 = 0;
                 cont->setData(val32);
                 break;
             }
-            catch (std::out_of_range)
+            catch (std::out_of_range&)
             {
                 status = CONVERT_STATUS_INVALID;
                 val32 = 0;
@@ -1376,14 +1376,14 @@ columnstore_data_convert_status_t ColumnStoreDataConvert::convert(ColumnStoreSys
             {
                 val64 = stoll(fromValue);
             }
-            catch (std::invalid_argument)
+            catch (std::invalid_argument&)
             {
                 status = CONVERT_STATUS_INVALID;
                 val64 = 0;
                 cont->setData(val64);
                 break;
             }
-            catch (std::out_of_range)
+            catch (std::out_of_range&)
             {
                 status = CONVERT_STATUS_INVALID;
                 val64 = 0;
@@ -1411,14 +1411,14 @@ columnstore_data_convert_status_t ColumnStoreDataConvert::convert(ColumnStoreSys
             {
                 valD = stod(fromValue);
             }
-            catch (std::invalid_argument)
+            catch (std::invalid_argument&)
             {
                 status = CONVERT_STATUS_INVALID;
                 val64 = 0;
                 cont->setData(val64);
                 break;
             }
-            catch (std::out_of_range)
+            catch (std::out_of_range&)
             {
                 status = CONVERT_STATUS_INVALID;
                 val64 = 0;
@@ -1482,14 +1482,14 @@ columnstore_data_convert_status_t ColumnStoreDataConvert::convert(ColumnStoreSys
             {
                 uval64 = stoull(fromValue);
             }
-            catch (std::invalid_argument)
+            catch (std::invalid_argument&)
             {
                 status = CONVERT_STATUS_INVALID;
                 uval8 = 0;
                 cont->setData(uval8);
                 break;
             }
-            catch (std::out_of_range)
+            catch (std::out_of_range&)
             {
                 status = CONVERT_STATUS_INVALID;
                 uval8 = 0;
@@ -1516,14 +1516,14 @@ columnstore_data_convert_status_t ColumnStoreDataConvert::convert(ColumnStoreSys
             {
                 uval64 = stoull(fromValue);
             }
-            catch (std::invalid_argument)
+            catch (std::invalid_argument&)
             {
                 status = CONVERT_STATUS_INVALID;
                 uval16 = 0;
                 cont->setData(uval16);
                 break;
             }
-            catch (std::out_of_range)
+            catch (std::out_of_range&)
             {
                 status = CONVERT_STATUS_INVALID;
                 uval16 = 0;
@@ -1550,14 +1550,14 @@ columnstore_data_convert_status_t ColumnStoreDataConvert::convert(ColumnStoreSys
             {
                 uval64 = stoull(fromValue);
             }
-            catch (std::invalid_argument)
+            catch (std::invalid_argument&)
             {
                 status = CONVERT_STATUS_INVALID;
                 uval32 = 0;
                 cont->setData(uval32);
                 break;
             }
-            catch (std::out_of_range)
+            catch (std::out_of_range&)
             {
                 status = CONVERT_STATUS_INVALID;
                 uval32 = 0;
@@ -1584,14 +1584,14 @@ columnstore_data_convert_status_t ColumnStoreDataConvert::convert(ColumnStoreSys
             {
                 uval64 = stoull(fromValue);
             }
-            catch (std::invalid_argument)
+            catch (std::invalid_argument&)
             {
                 status = CONVERT_STATUS_INVALID;
                 uval32 = 0;
                 cont->setData(uval32);
                 break;
             }
-            catch (std::out_of_range)
+            catch (std::out_of_range&)
             {
                 status = CONVERT_STATUS_INVALID;
                 uval32 = 0;
@@ -1618,14 +1618,14 @@ columnstore_data_convert_status_t ColumnStoreDataConvert::convert(ColumnStoreSys
             {
                 uval64 = stoull(fromValue);
             }
-            catch (std::invalid_argument)
+            catch (std::invalid_argument&)
             {
                 status = CONVERT_STATUS_INVALID;
                 uval64 = 0;
                 cont->setData(uval64);
                 break;
             }
-            catch (std::out_of_range)
+            catch (std::out_of_range&)
             {
                 status = CONVERT_STATUS_INVALID;
                 uval64 = 0;

--- a/src/util_debug.h
+++ b/src/util_debug.h
@@ -18,8 +18,35 @@
 
 #pragma once
 
-void mcsdebug_set(bool enabled);
+#include <stdarg.h>
 
-void mcsdebug(const char* MSG, ...);
+void mcsdebug_set(uint8_t level);
 
-void mcsdebug_hex(const char* DATA, size_t LEN);
+uint8_t mcsdebug_get();
+
+void mcsdebug_impl(const char* MSG, const char* file, size_t line, va_list argptr);
+
+inline void mcsdebug(const char* MSG, ...)
+{
+    va_list argptr;
+    va_start(argptr, MSG);
+#ifdef _WIN32
+    mcsdebug_impl(MSG, __FILE__, __LINE__, argptr);
+#endif
+#ifdef __linux__
+    mcsdebug_impl(MSG, __FILENAME__, __LINE__, argptr);
+#endif
+    va_end(argptr);
+}
+
+void mcsdebug_hex_impl(const char* DATA, size_t LEN, const char* file, size_t line);
+
+inline void mcsdebug_hex(const char* DATA, size_t LEN)
+{
+#ifdef _WIN32
+    mcsdebug_hex_impl(DATA, LEN, __FILE__, __LINE__);
+#endif
+#ifdef __linux__
+    mcsdebug_hex_impl(DATA, LEN, __FILENAME__, __LINE__);
+#endif
+}

--- a/src/util_network.cpp
+++ b/src/util_network.cpp
@@ -81,7 +81,10 @@ void ColumnStoreNetwork::onResolved(uv_getaddrinfo_t* resolver,
 {
     // Fake a 'this' for a callback
     ColumnStoreNetwork* This = (ColumnStoreNetwork*)resolver->data;
-    mcsdebug("Class %p resolver callback", (void*)This);
+    if (mcsdebug_get() > 1)
+    {
+        mcsdebug("Class %p resolver callback", (void*)This);
+    }
     if (status < 0)
     {
         mcsdebug("Class %p failed resolving: %s", (void*)This, uv_err_name(status));
@@ -92,7 +95,10 @@ void ColumnStoreNetwork::onResolved(uv_getaddrinfo_t* resolver,
     }
     char addr[17] = {'\0'};
 
-    mcsdebug("Class %p resolving success", (void*)This);
+    if (mcsdebug_get() > 1)
+    {
+        mcsdebug("Class %p resolving success", (void*)This);
+    }
     uv_ip4_name((struct sockaddr_in*) res->ai_addr, addr, 16);
     uv_tcp_init(This->uv_loop, &This->uv_tcp);
     This->uv_tcp.data = This;
@@ -108,7 +114,10 @@ void ColumnStoreNetwork::onConnect(uv_connect_t* req, int status)
 {
     // Fake a 'this' for a callback
     ColumnStoreNetwork* This = (ColumnStoreNetwork*)req->handle->data;
-    mcsdebug("Class %p connect callback", (void*)This);
+    if (mcsdebug_get() > 1)
+    {
+        mcsdebug("Class %p connect callback", (void*)This);
+    }
     if (status < 0)
     {
         mcsdebug("Class %p connection failure: %s", (void*)This, uv_err_name(status));
@@ -264,7 +273,10 @@ void ColumnStoreNetwork::onWriteData(uv_write_t* req, int status)
 {
     // Fake a 'this' for a callback
     ColumnStoreNetwork* This = (ColumnStoreNetwork*)req->data;
-    mcsdebug("Class %p write callback", (void*)This);
+    if (mcsdebug_get() > 1)
+    {
+        mcsdebug("Class %p write callback", (void*)This);
+    }
     delete req;
     delete[] This->buf;
     This->buf = nullptr;
@@ -381,7 +393,10 @@ void ColumnStoreNetwork::readDataStart()
     this->con_status = CON_STATUS_BUSY;
     dataInBuffer = 0;
     this->messageOut = new ColumnStoreMessaging();
-    mcsdebug("Class %p starting read", this);
+    if (mcsdebug_get() > 1)
+    {
+        mcsdebug("Class %p starting read", this);
+    }
 
     ret = uv_read_start(this->uv_stream, ColumnStoreNetwork::onAlloc, ColumnStoreNetwork::onReadData);
     if (ret < 0)
@@ -402,9 +417,15 @@ void ColumnStoreNetwork::readDataStop()
 void ColumnStoreNetwork::onAlloc(uv_handle_t *client, size_t suggested_size, uv_buf_t *buf)
 {
     ColumnStoreNetwork* This = (ColumnStoreNetwork*)client->data;
-    mcsdebug("Class %p request to increase read buffer to %zu bytes", (void*)This, suggested_size);
+    if (mcsdebug_get() > 1)
+    {
+        mcsdebug("Class %p request to increase read buffer to %zu bytes", (void*)This, suggested_size);
+    }
     This->messageOut->allocateDataSize(suggested_size);
-    mcsdebug("Class %p read buffer is now %zu bytes", (void*)This, This->messageOut->getBufferFreeSize());
+    if (mcsdebug_get() > 1)
+    {
+        mcsdebug("Class %p read buffer is now %zu bytes", (void*)This, This->messageOut->getBufferFreeSize());
+    }
     buf->base = reinterpret_cast<char*>(This->messageOut->getBufferEmptyPos());
     buf->len = This->messageOut->getBufferFreeSize();
 }

--- a/test/dataconvert-datetime.cpp
+++ b/test/dataconvert-datetime.cpp
@@ -87,7 +87,7 @@ TEST(DataConvertDateTime, DataConvertFormats)
     try {
         driver = new mcsapi::ColumnStoreDriver();
         bulk = driver->createBulkInsert("mcsapi", "dataconvertdatetime2", 0, 0);
-        for (int i=0; i<(sizeof(datetimes)/sizeof(datetimes[0])) && i<(sizeof(formats)/sizeof(formats[0])); i++){
+        for (size_t i=0; i<(sizeof(datetimes)/sizeof(datetimes[0])) && i<(sizeof(formats)/sizeof(formats[0])); i++){
             std::cout << "trying to inject datetime '" << datetimes[i] << "' with format '" << formats[i] << "'" << std::endl;
             mcsapi::ColumnStoreDateTime dt = mcsapi::ColumnStoreDateTime(datetimes[i], formats[i]);
             bulk->setColumn(0,dt);


### PR DESCRIPTION
This branch does the following:

* Fix issue where line numbers and file names were only showing
util_debug entries
* Add debug levels to setDebug()
  - 1 is less verbose and truncates at 1000 bytes
  - 2 is as before
* Fix a bunch of GCC 8 compiler warnings