### PR TITLE
MCOL-1362 - scala function exportFromWorkers('database', 'table', RDD…

### DIFF
--- a/spark-connector/scala/README.md
+++ b/spark-connector/scala/README.md
@@ -1,12 +1,14 @@
 # MariaDB ColumnStore API Scala Spark Connector
 This provides a connector between the MariaDB ColumnStore API Java Wrapper and Spark.
 
-Currently there are two functions.
+Currently there are three functions.
 ```scala
 ColumnStoreExporter.export("database", "table", DataFrame, [path to Columnstore.xml])
+ColumnStoreExporter.exportFromWorkers("database", "table", RDD, [path to Columnstore.xml])
 ColumnStoreExporter.generateTableStatement(DataFrame, ["database", "table", determineTypeLength])
 ```
-export() exports a DataFrame to an existing table, and 
+export() exports a DataFrame from the Spark Driver in one transaction to an existing table,  
+exportFromWorkers() exports a RDD into an existing ColumnStore table by writing each partition as one transaction from the Spark Workers into ColumnStore, and 
 generateTableStatement() generates a CREATE TABLE SQL statement based on the schema of the DataFrame to export.
 
 ## Benchmarking

--- a/spark-connector/scala/build.gradle
+++ b/spark-connector/scala/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 if (project.property('version').equals('unspecified')){
-    version '1.1.6'
+    version '1.2.1'
 } else{
     version project.property('version')
 }

--- a/spark-connector/scala/src/main/scala/com/mariadb/columnstore/api/connector/ColumnStoreExporter.scala
+++ b/spark-connector/scala/src/main/scala/com/mariadb/columnstore/api/connector/ColumnStoreExporter.scala
@@ -16,7 +16,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 MA 02110-1301  USA
 */
 
-import com.mariadb.columnstore.api.{ColumnStoreDriver,ColumnStoreDecimal,columnstore_data_types_t}
+import com.mariadb.columnstore.api._
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.{max,length,udf}
 import org.apache.spark.sql.types
@@ -24,6 +24,8 @@ import java.math.BigInteger
 import java.math.BigDecimal
 import java.util.regex.Pattern
 import java.io.{InputStream,BufferedReader,IOException,InputStreamReader}
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
 
 object ColumnStoreExporter {
 
@@ -218,6 +220,56 @@ object ColumnStoreExporter {
       return output.toString();
   }
 
+  /**
+  / Writes a row into ColumnStore
+  */
+  @throws(classOf[Exception])
+  def writeRow (row: org.apache.spark.sql.Row, dbTableColumnCount: Integer, dbTable: ColumnStoreSystemCatalogTable, bulkInsert: ColumnStoreBulkInsert) : Unit = {
+  for (columnId <- 0 until row.size){
+    if (columnId < dbTableColumnCount){
+      if (row.get(columnId) == null){
+        if(dbTable.getColumn(columnId).isNullable){
+          bulkInsert.setNull(columnId)
+        } else{
+          System.err.println("warning: column " + columnId + " is not nullable. Using default value instead.")
+          bulkInsert.setColumn(columnId, dbTable.getColumn(columnId).getDefaultValue())
+        }
+      } else{
+          row.get(columnId) match {
+            case input:Boolean => bulkInsert.setColumn(columnId, input)
+            case input:Byte => bulkInsert.setColumn(columnId, input)
+            case input:java.sql.Date => bulkInsert.setColumn(columnId, input.toString)
+            case input:java.math.BigDecimal =>
+              val dbColumn = dbTable.getColumn(columnId)
+              if (dbColumn.getType.equals(columnstore_data_types_t.DATA_TYPE_DECIMAL) ||
+                  dbColumn.getType.equals(columnstore_data_types_t.DATA_TYPE_UDECIMAL) ||
+                  dbColumn.getType.equals(columnstore_data_types_t.DATA_TYPE_FLOAT) ||
+                  dbColumn.getType.equals(columnstore_data_types_t.DATA_TYPE_UFLOAT) ||
+                  dbColumn.getType.equals(columnstore_data_types_t.DATA_TYPE_DOUBLE) ||
+                  dbColumn.getType.equals(columnstore_data_types_t.DATA_TYPE_UDOUBLE)){
+                    bulkInsert.setColumn(columnId, new ColumnStoreDecimal(input.toPlainString))
+              }
+              else {
+                bulkInsert.setColumn(columnId, input.toBigInteger)
+              }
+            case input:Double => bulkInsert.setColumn(columnId, input)
+            case input:Float => bulkInsert.setColumn(columnId, input)
+            case input:Integer => bulkInsert.setColumn(columnId, input)
+            case input:Long => bulkInsert.setColumn(columnId, input)
+            case input:Short => bulkInsert.setColumn(columnId, input)
+            case input:String => bulkInsert.setColumn(columnId, input)
+            case input:java.sql.Timestamp => bulkInsert.setColumn(columnId, input.toString)
+            case _ => throw new Exception("Parsing error, can't convert " +  row.get(columnId).getClass + ".")
+          }
+        }
+      }
+    }
+    bulkInsert.writeRow()
+  }
+  
+  /**
+  * Export function to export a DataFrame into an existing ColumnStore table by writing everything in one transaction from the Spark Driver.
+  */
   def export( database: String, table: String, df: DataFrame, configuration: String = "") : Unit = {
     var driver: ColumnStoreDriver = null
     if (configuration == ""){
@@ -236,51 +288,7 @@ object ColumnStoreExporter {
     // insert row by row into table
     try {
       for (row <- df.rdd.toLocalIterator){
-        for (columnId <- 0 until row.size){
-          if (columnId < dbTableColumnCount){
-            if (row.get(columnId) == null){
-              if(dbTable.getColumn(columnId).isNullable){
-                  bulkInsert.setNull(columnId)
-              } else{
-                  System.err.println("warning: column " + columnId + " is not nullable. Using default value instead.")
-                  bulkInsert.setColumn(columnId, dbTable.getColumn(columnId).getDefaultValue())
-              }
-            } else{
-              row.get(columnId) match {
-                case input:Boolean => 
-                if (input){
-                  bulkInsert.setColumn(columnId, 1)
-                } else{
-                  bulkInsert.setColumn(columnId, 0)
-                }
-                case input:Byte => bulkInsert.setColumn(columnId, input)
-                case input:java.sql.Date => bulkInsert.setColumn(columnId, input.toString)
-                case input:java.math.BigDecimal =>
-                  val dbColumn = dbTable.getColumn(columnId)
-                  if (dbColumn.getType.equals(columnstore_data_types_t.DATA_TYPE_DECIMAL) ||
-                    dbColumn.getType.equals(columnstore_data_types_t.DATA_TYPE_UDECIMAL) ||
-                    dbColumn.getType.equals(columnstore_data_types_t.DATA_TYPE_FLOAT) ||
-                    dbColumn.getType.equals(columnstore_data_types_t.DATA_TYPE_UFLOAT) ||
-                    dbColumn.getType.equals(columnstore_data_types_t.DATA_TYPE_DOUBLE) ||
-                    dbColumn.getType.equals(columnstore_data_types_t.DATA_TYPE_UDOUBLE)){
-                      bulkInsert.setColumn(columnId, new ColumnStoreDecimal(input.toPlainString))
-                  }
-                  else {
-                    bulkInsert.setColumn(columnId, input.toBigInteger)
-                  }
-                case input:Double => bulkInsert.setColumn(columnId, input)
-                case input:Float => bulkInsert.setColumn(columnId, input)
-                case input:Integer => bulkInsert.setColumn(columnId, input)
-                case input:Long => bulkInsert.setColumn(columnId, input)
-                case input:Short => bulkInsert.setColumn(columnId, input)
-                case input:String => bulkInsert.setColumn(columnId, input)
-                case input:java.sql.Timestamp => bulkInsert.setColumn(columnId, input.toString)
-                case _ => throw new Exception("Parsing error, can't convert " +  row.get(columnId).getClass + ".")
-              }
-            }
-          }
-        }
-        bulkInsert.writeRow()
+        writeRow(row, dbTableColumnCount, dbTable, bulkInsert)
       }
       bulkInsert.commit()
     }
@@ -296,5 +304,53 @@ object ColumnStoreExporter {
       println("Invalid count: " + summary.getInvalidCount)
     }
   }
-}
+  
+  /**
+  * Export function to export a RDD into an existing ColumnStore table by writing each partition as one transaction from the Spark Workers into ColumnStore.
+  */
+  def exportFromWorkers[Row] (database: String, table: String, rdd: RDD[Row], configuration: String = "") : Unit = {
+    println("number of partitions: " + rdd.getNumPartitions)
+    for(p <- 0 until rdd.getNumPartitions){
+        println("Exporting partition " + p)
+        rdd.sparkContext.runJob(rdd,(iter: Iterator[Row]) => {
+             // initialize the ColumnStore Driver on the Worker 
+            var driver: ColumnStoreDriver = null
+            if (configuration == ""){
+              driver = new ColumnStoreDriver()
+            }
+            else{
+              driver = new ColumnStoreDriver(configuration)
+            }
+            val bulkInsert = driver.createBulkInsert(database, table, 0, 0)
 
+            // get the column count of the CS table
+            val dbCatalog = driver.getSystemCatalog
+            val dbTable = dbCatalog.getTable(database, table)
+            val dbTableColumnCount = dbTable.getColumnCount
+            
+            // insert row by row into table
+            try{
+              while(iter.hasNext){
+                var row = iter.next()
+                row match {
+                    case row: org.apache.spark.sql.Row => writeRow(row, dbTableColumnCount, dbTable, bulkInsert)
+                    case _ => println("Wasn't able to inject row: " + row + "\nThe row type doesn't match.")
+                }
+              }
+              bulkInsert.commit()
+            }
+            catch {
+              case e: Exception => bulkInsert.rollback(); e.printStackTrace();
+            }
+            finally{ // print a short summary of the insertion process
+              val summary = bulkInsert.getSummary
+              println("Execution time: " + summary.getExecutionTime)
+              println("Rows inserted: " + summary.getRowsInsertedCount)
+              println("Truncation count: " + summary.getTruncationCount)
+              println("Saturated count: " + summary.getSaturatedCount)
+              println("Invalid count: " + summary.getInvalidCount)
+            }
+        }, List(p))
+    }
+  }
+}

--- a/spark-connector/scala/src/test/scala/com/mariadb/columnstore/api/connector/ColumnStoreExporterTestFromWorker.scala
+++ b/spark-connector/scala/src/test/scala/com/mariadb/columnstore/api/connector/ColumnStoreExporterTestFromWorker.scala
@@ -1,0 +1,212 @@
+package com.mariadb.columnstore.api.connector
+
+/*
+Copyright (c) 2018, MariaDB Corporation. All rights reserved.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301  USA
+*/
+
+import java.math.{BigDecimal,BigInteger,MathContext}
+import org.apache.spark.sql.SparkSession
+import org.junit.Test
+import java.util.Properties
+import org.junit.Assert._
+import java.sql.{DriverManager,Connection,Date,Timestamp,PreparedStatement,ResultSet,SQLException}
+
+class ColumnStoreExporterTestFromWorker {
+
+  /**
+    * Basic test to test the insertion of common data types.
+    */
+  @Test
+  def testBasic() : Unit = {
+
+    //initialize the spark session
+    lazy val spark: SparkSession = SparkSession.builder.master("local").appName("spark-scala-connector-test-worker-export").getOrCreate
+    import spark.implicits._
+    
+    //get connection data
+    var host = "127.0.0.1"
+    var user = "root"
+    if (sys.env.get("MCSAPI_CS_TEST_IP") != None){
+        host = sys.env.get("MCSAPI_CS_TEST_IP").get
+    }
+    if (sys.env.get("MCSAPI_CS_TEST_USER") != None){
+        user = sys.env.get("MCSAPI_CS_TEST_USER").get
+    }
+
+    //create the test table
+    val url = "jdbc:mysql://"+host+":3306/test"
+    val connectionProperties = new Properties()
+    connectionProperties.put("user", user)
+    connectionProperties.put("driver", "org.mariadb.jdbc.Driver")
+    if (sys.env.get("MCSAPI_CS_TEST_PASSWORD") != None){
+        connectionProperties.put("password",sys.env.get("MCSAPI_CS_TEST_PASSWORD").get)
+    }
+    var connection: Connection = null
+    try {
+      connection = DriverManager.getConnection(url, connectionProperties)
+      val statement = connection.createStatement
+      statement.executeQuery("""DROP TABLE IF EXISTS scalatest_w_""")
+      statement.executeQuery("""DROP TABLE IF EXISTS scalatest_w_2""")
+      statement.executeQuery(
+        """
+        CREATE TABLE scalatest_w_ (
+        uint64 bigint unsigned,
+        int64 bigint,
+        uint32 int unsigned,
+        int32 int,
+        uint16 smallint unsigned,
+        int16 smallint,
+        uint8 tinyint unsigned,
+        `int8` tinyint,
+        f float,
+        d double,
+        ch4 char(5),
+        vch30 varchar(30),
+        dt date,
+        dtm datetime,
+        dc decimal(18),
+        tx text,
+        bit tinyint(1),
+        mathInt bigint unsigned,
+        dc2 decimal(18,9))
+        ENGINE=columnstore""")
+        
+    statement.executeQuery(
+        """    
+        CREATE TABLE scalatest_w_2 (
+        uint64 bigint unsigned,
+        int64 bigint,
+        uint32 int unsigned,
+        int32 int,
+        uint16 smallint unsigned,
+        int16 smallint,
+        uint8 tinyint unsigned,
+        `int8` tinyint,
+        f float,
+        d double,
+        ch4 char(5),
+        vch30 varchar(30),
+        dt date,
+        dtm datetime,
+        dc decimal(18),
+        tx text,
+        bit tinyint(1),
+        mathInt bigint unsigned,
+        dc2 decimal(18,9))
+        ENGINE=columnstore""")
+
+      //create the test dataframe
+      val testDF = Seq(
+        (1L, 2L, 3L, new Integer(4), new Integer(5), new Integer(6), new Integer(7), new Integer(8), 1.234F, 2.34567F, "ABCD", "Hello World", Date.valueOf("2017-09-08"), Timestamp.valueOf("2017-09-08 13:58:23"), new BigDecimal(123), "Hello World Longer", true, new BigInteger("9223372036854775807"), new BigDecimal("-0.000000001", MathContext.UNLIMITED)),
+        (0L, -9223372036854775806L, 0L, new Integer(-2147483646), new Integer(0), new Integer(-32766), new Integer(0), new Integer(-126), 1.234F, 2.34567F, "A", "B", Date.valueOf("1000-01-01"), Timestamp.valueOf("1000-01-01 00:00:00"), new BigDecimal(-123), "C", false, new BigInteger("18446744073709551613"), new BigDecimal("100000000.999999999", MathContext.UNLIMITED)),
+        (9223372036854775807L, 9223372036854775807L, 4294967293L, new Integer(2147483647), new Integer(65533), new Integer(32767), new Integer(253), new Integer(127), 1.234F, 2.34567F, "ZYXW", "012345678901234567890123456789", Date.valueOf("9999-12-31"), Timestamp.valueOf("9999-12-31 23:59:59"), new BigDecimal(123), "012345678901234567890123456789", true, new BigInteger("2342"), new BigDecimal("23.42")),
+        (42L, 43L, 44L, null.asInstanceOf[Integer], null.asInstanceOf[Integer], null.asInstanceOf[Integer], null.asInstanceOf[Integer], null.asInstanceOf[Integer], 3.45F, 556.3F, null, null, null, null, null, null, false, null, null)
+      ).toDF("uint64", "int64", "uint32", "int32", "uint16", "int16", "uint8", "int8", "f", "d", "ch4", "vch30", "dt", "dtm", "dc", "tx", "bit", "mathInt", "dc2")
+
+      //write the test dataframe into columnstore
+      ColumnStoreExporter.exportFromWorkers("test", "scalatest_w_", testDF.rdd)
+      if (sys.env.get("COLUMNSTORE_INSTALL_DIR") != None){
+        ColumnStoreExporter.exportFromWorkers("test", "scalatest_w_2", testDF.rdd, sys.env.get("COLUMNSTORE_INSTALL_DIR").get+"/etc/Columnstore.xml")
+      }else{
+        ColumnStoreExporter.exportFromWorkers("test", "scalatest_w_2", testDF.rdd, "/usr/local/mariadb/columnstore/etc/Columnstore.xml")
+      }
+      
+      verifyAllTypes(connection, 1L, "1, 2, 3, 4, 5, 6, 7, 8, 1.234, 2.345669984817505, ABCD, Hello World, 2017-09-08, 2017-09-08 13:58:23.0, 123, Hello World Longer, true, 9223372036854775807, -1E-9")
+      verifyAllTypes(connection, 0L, "0, -9223372036854775806, 0, -2147483646, 0, -32766, 0, -126, 1.234, 2.345669984817505, A, B, 1000-01-01, 1000-01-01 00:00:00.0, -123, C, false, 18446744073709551613, 100000000.999999999")
+      verifyAllTypes(connection, 9223372036854775807L, "9223372036854775807, 9223372036854775807, 4294967293, 2147483647, 65533, 32767, 253, 127, 1.234, 2.345669984817505, ZYXW, 012345678901234567890123456789, 9999-12-31, 9999-12-31 23:59:59.0, 123, 012345678901234567890123456789, true, 2342, 23.420000000")
+      verifyAllTypes(connection, 42L, "42, 43, 44, null, null, null, null, null, 3.45, 556.2999877929688, null, null, null, null, null, null, false, null, null")
+      verifyAllTypes2(connection, 1L, "1, 2, 3, 4, 5, 6, 7, 8, 1.234, 2.345669984817505, ABCD, Hello World, 2017-09-08, 2017-09-08 13:58:23.0, 123, Hello World Longer, true, 9223372036854775807, -1E-9")
+      verifyAllTypes2(connection, 0L, "0, -9223372036854775806, 0, -2147483646, 0, -32766, 0, -126, 1.234, 2.345669984817505, A, B, 1000-01-01, 1000-01-01 00:00:00.0, -123, C, false, 18446744073709551613, 100000000.999999999")
+      verifyAllTypes2(connection, 9223372036854775807L, "9223372036854775807, 9223372036854775807, 4294967293, 2147483647, 65533, 32767, 253, 127, 1.234, 2.345669984817505, ZYXW, 012345678901234567890123456789, 9999-12-31, 9999-12-31 23:59:59.0, 123, 012345678901234567890123456789, true, 2342, 23.420000000")
+      verifyAllTypes(connection, 42L, "42, 43, 44, null, null, null, null, null, 3.45, 556.2999877929688, null, null, null, null, null, null, false, null, null")
+ 
+      //drop the test table
+      statement.executeQuery("""DROP TABLE IF EXISTS scalatest_w_""")
+      statement.executeQuery("""DROP TABLE IF EXISTS scalatest_w_2""")
+    } catch {
+      case e: Exception => fail("error during test: " + e)
+    } finally {
+      connection.close()
+    }
+  }
+
+  /**
+    * Tests if the data stored in the database equals the expected value.
+    * @param conn, MariaDB connection
+    * @param id, id of the database row
+    * @param expected, the expected value
+    */
+  private def verifyAllTypes(conn: Connection, id: Long, expected: String) : Unit = {
+    val QUERY_ALL_TYPES = "select uint64, int64, uint32, int32, uint16, int16, uint8, `int8`, " +
+      "f, d, ch4, vch30, dt, dtm, dc, tx, bit, mathInt, dc2 from scalatest_w_ where uint64 = ?"
+    var stmt: PreparedStatement = null
+    var rs: ResultSet = null
+    try {
+      stmt = conn.prepareStatement(QUERY_ALL_TYPES)
+      stmt.setLong(1, id)
+      rs = stmt.executeQuery
+      assertTrue(rs.next)
+      val str = new StringBuffer
+      val colCount = stmt.getMetaData.getColumnCount
+      for (i <- 1 to colCount){
+        if (i>1) str.append(", ")
+        str.append(rs.getObject(i))
+      }
+      assertEquals(expected, str.toString)
+    }
+    catch {
+      case e: SQLException => fail("Error while validating all_types results for id: " + id + ", error:" + e)
+    }
+    finally {
+      rs.close()
+      stmt.close()
+    }
+  }
+  
+    /**
+    * Tests if the data stored in the database equals the expected value.
+    * @param conn, MariaDB connection
+    * @param id, id of the database row
+    * @param expected, the expected value
+    */
+  private def verifyAllTypes2(conn: Connection, id: Long, expected: String) : Unit = {
+    val QUERY_ALL_TYPES = "select uint64, int64, uint32, int32, uint16, int16, uint8, `int8`, " +
+      "f, d, ch4, vch30, dt, dtm, dc, tx, bit, mathInt, dc2 from scalatest_w_2 where uint64 = ?"
+    var stmt: PreparedStatement = null
+    var rs: ResultSet = null
+    try {
+      stmt = conn.prepareStatement(QUERY_ALL_TYPES)
+      stmt.setLong(1, id)
+      rs = stmt.executeQuery
+      assertTrue(rs.next)
+      val str = new StringBuffer
+      val colCount = stmt.getMetaData.getColumnCount
+      for (i <- 1 to colCount){
+        if (i>1) str.append(", ")
+        str.append(rs.getObject(i))
+      }
+      assertEquals(expected, str.toString)
+    }
+    catch {
+      case e: SQLException => fail("Error while validating all_types results for id: " + id + ", error:" + e)
+    }
+    finally {
+      rs.close()
+      stmt.close()
+    }
+  }
+}
+
+


### PR DESCRIPTION
…, columnstore_xml) added to export a RDD from the workers instead of from the Spark driver. This function will create as many transactions as partitions. Test added to the regression suite and README.md updated as well.

PLEASE DO NOT MERGE, I JUST NEED THE DPKG PACKAGES FROM BUILDBOT FOR TESTING