### PR TITLE
Add .NET Core API and NuGet Package (using swig)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,25 @@ build/
 java/libjavamcsapi.so*
 docs/example
 
+#We need simutaneous builds for the dotnet NuGet package
+build-win-x64
+build-linux-x64
+
+#Just about everything in dotnet is created, esp. noteable
+#  are the src/*.cs files which come from swig.
+dotnet/dotnet_mcsapi_wrap.cxx
+dotnet/src/bin/
+dotnet/src/obj/
+dotnet/src/*.cs
+dotnet/test/bin
+dotnet/test/obj
+dotnet/example/bin
+dotnet/example/obj
+dotnet/lib-win-x64
+dotnet/lib-linux-x64
+dotnet/build-win-x64
+dotnet/build-linux-x64
+
 # QtCreator files
 *.config
 *.creator

--- a/dotnet/CMakeLists.txt
+++ b/dotnet/CMakeLists.txt
@@ -1,0 +1,67 @@
+cmake_minimum_required(VERSION 2.8.11)
+
+include_directories(..)
+#Find the packages and libraries
+IF(WIN32)
+    SET(FIND_LIBRARY_USE_LIB64_PATHS ON)
+    SET(ENGINE_ARCH "x64")
+ENDIF(WIN32)
+
+IF(UNIX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__FILENAME__='\"$(subst ${CMAKE_SOURCE_DIR}/,,$(abspath $<))\"'")
+ENDIF(UNIX)
+IF(WIN32)
+    #TODO find a way to define the __FILENAME__ in Windows so that the debug output doesn't contain the absolute path.
+    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__FILENAME__=\"$(notdir $<)\"")
+ENDIF(WIN32)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILDING_MYMCSAPI")
+
+set(DOTNET_AVAILABLE 0)
+
+execute_process(COMMAND dotnet --version OUTPUT_VARIABLE DOTNET_VERSION_AVAILABLE OUTPUT_STRIP_TRAILING_WHITESPACE)
+IF(DOTNET_VERSION_AVAILABLE VERSION_GREATER 2.0)
+    set(DOTNET_AVAILABLE 1)
+    MESSAGE(STATUS "dotnet ${DOTNET_VERSION_AVAILABLE} Found")
+ENDIF(DOTNET_VERSION_AVAILABLE VERSION_GREATER 2.0)
+
+IF(NOT DOTNET_AVAILABLE)
+    MESSAGE(FATAL_ERROR "dotnet command line not available")
+ENDIF()
+
+#Checking for SWIG
+find_package(SWIG 3 REQUIRED)
+
+IF(DOTNET_AVAILABLE)
+    MESSAGE(STATUS "Have dotnet... generate wrapper code and makefile")
+
+    get_filename_component(INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}" DIRECTORY)
+
+    set(SWIG_DOTNET_WRAPPER_SOURCE
+	"${CMAKE_CURRENT_SOURCE_DIR}/dotnet_mcsapi_wrap.cxx")
+
+
+    MESSAGE(STATUS "Have dotnet... Add generate wrapper code to build process ${SWIG_DOTNET_WRAPPER_SOURCE}")
+    MESSAGE(STATUS "${SWIG_EXECUTABLE} -c++ -csharp -I${INCLUDE_DIR} -namespace MariaDB.Data.ColumnStore -outdir ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR}/dotnet_mcsapi.i")
+
+    add_custom_command(OUTPUT ${SWIG_DOTNET_WRAPPER_SOURCE}
+	    COMMAND ${SWIG_EXECUTABLE} -c++ -csharp -I${INCLUDE_DIR} -namespace MariaDB.Data.ColumnStore -outdir ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR}/dotnet_mcsapi.i
+        COMMENT "Generating the dotnet/c# wrapper source code")
+
+    add_library(dotnet_mcsapi SHARED "${SWIG_DOTNET_WRAPPER_SOURCE}")
+    set_target_properties(dotnet_mcsapi PROPERTIES OUTPUT_NAME "dotnet_mcsapi")
+    set_target_properties(dotnet_mcsapi PROPERTIES PREFIX "")
+    set_target_properties(dotnet_mcsapi PROPERTIES LIBRARY_OUTPUT_DIRECTORY "glue-lib")
+    IF(WIN32)
+        set_target_properties(dotnet_mcsapi PROPERTIES RUNTIME_OUTPUT_DIRECTORY "glue-lib")
+        target_link_libraries(dotnet_mcsapi ../lib-win-x64/mcsapi)
+    ENDIF(WIN32)
+    IF(UNIX)
+        target_link_libraries(dotnet_mcsapi mcsapi)
+        target_link_libraries(dotnet_mcsapi libmcsapi.a)
+    ENDIF(UNIX)
+
+    # Directory may not exist, so we'll copy the library in the csproj file.
+    # install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/dotnet_build/dotnet_mcsapi.so" DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/test/obj/Debug/netcoreapp2.1/")
+
+ENDIF()
+

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1,0 +1,201 @@
+# MariaDB.Data.ColumnStore.ColumnStoreDriver
+
+.NET Core wrapper on the ColumnStore c++ API for Linux (x64) and Windows (x64).
+
+## Getting Started
+
+Riffing off of [MariaDB ColumnStore Bulk Write SDK](https://mariadb.com/kb/en/library/columnstore-bulk-write-sdk/)...
+
+First a simple table is created with the mcsmysql client:
+
+```sql
+MariaDB [test]> create table t1(i int, c char(3)) engine=columnstore;
+```
+
+Next, create a new console project
+
+```shell
+mkdir ColumnStoreTestProgram
+cd ColumnStoreTestProgram
+dotnet new console
+```
+
+Alter Program.cs
+
+```cs
+using System;
+using MariaDB.Data.ColumnStore;
+
+namespace ColumnStoreTestProgram
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            // For windows, name the XML file location
+            var ColumnstoreXmlFilePath = @"C:\opt\mariadb\etc\Columnstore.xml";
+            var d = new ColumnStoreDriver(ColumnstoreXmlFilePath);
+            var b = d.createBulkInsert("mcsapi", "t1", 0, 0);
+            try
+            {
+                b.setColumn(0, 2);
+                b.setColumn(1, "c#!");
+                b.writeRow();
+                b.commit();
+            }
+            catch (Exception e)
+            {
+                b.rollback();
+                Console.WriteLine(e.StackTrace);
+            }
+        }
+    }
+}
+```
+
+And run
+
+```shell
+dotnet run
+```
+
+Now back in mcsmysql verify the data is written:
+
+```misc
+MariaDB [test]> select * from t1;
++------+------+
+| i    | c    |
++------+------+
+|    2 | c#!  |
++------+------+
+```
+
+### Windows
+
+Note that when using this driver from windows, one must use the constructor that
+takes a string pointing to the ```Columnstore.xml``` file, as shown above, otherwise
+it will throw an exception since by default the constructor will look in UNIX-y type
+locations.
+
+```cs
+using MariaDB.Data.ColumnStore;
+...
+var mcsConnection = new ColumnStoreDriver(@"C:\opt\mariadb\etc\Columnstore.xml");
+```
+
+### Further Examples
+
+Also look at ```dotnet/test/ColumnStoreTest.cs``` for some hints on how to use this
+package with some startup checks.
+
+## Building the NuGet Package
+
+Building the combination NuGet package requires a build environment for each
+target platform. The simplest way to build the Linux + Win combination is by
+using Windows 10 with gitbash coupled with the Windows Subsystem for Linux. (Of course
+it is also possible to compile the wrapper on each platform and copy the needed
+files over to a single system for the final NuGet pack.)
+
+Requirements:
+
+* Windows 10
+* [Visual Studio Community Edition](https://visualstudio.microsoft.com/vs/community/)
+* [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10) (with a c++ development environment)
+* [gitbash](https://git-scm.com/downloads)
+* The other build requirements for the API
+
+### Get the Source Code
+
+For building the Linux shared object with WSL, the source code needs to be located
+on a Windows partition because WSL can see windows files (under /mnt/DRIVE) but
+not the other way around.
+
+In Windows (gitbash):
+
+```shell
+mkdir ~/Code/external
+cd ~/Code/external
+git clone https://github.com/mariadb-corporation/mariadb-columnstore-api.git
+cd ~/Code/external/mariadb-columnstore-api
+```
+
+### Build the Windows API DLL
+
+The main README contains instructions on how to build the windows DLL.
+Or try using [build-win-x64.sh](https://gist.github.com/TikiBill/3dc83d90e5337eb168da82c207f077e3)
+from a windows gitbash prompt. Copy that file into mariadb-columnstore-api/extra and then run
+it from gitbash.
+
+### Copy the Windows DLLs
+
+The resulting API DLL and LIB, along with the support DLLs (libxml2, libuv, libiconv), need to
+be copied into dotnet/lib-win-x64. Assuming your build directory was build-win-x64:
+
+```shell
+cd ~/Code/external/mariadb-columnstore-api
+mkdir dotnet/lib-win-x64
+cp -v build-win-x64/src/RelWithDebInfo/mcsapi.dll dotnet/lib-win-x64
+cp -v build-win-x64/src/RelWithDebInfo/mcsapi.lib dotnet/lib-win-x64
+cp -v path/to/lib/libiconv.dll dotnet/lib-win-x64
+cp -v path/to/lib/libuv.dll dotnet/lib-win-x64
+cp -v path/to/lib/libxml2.dll dotnet/lib-win-x64
+```
+
+### Build the .NET Glue (Windows)
+
+Run ```dotnet/build.sh``` to walk through building the windows glue dll and
+c# files. This will put ```dotnet_mcsapi.dll``` in ```dotnet/lib-win-x64``` as
+well as the .cs source files in ```dotnet/src```.
+
+Note this script will also try to copy the DLLs outlined above if you have not
+already done so.
+
+### Build and Copy the Linux API Shared Object (.so)
+
+Next, from WSL (or a linux box), follow the main README instructions to build
+the shared mcsapi.so library. The commands would be (assuming the C: drive
+contains your user directory, and your user name is USER):
+
+```shell
+cd  /mnt/c/Users/USER/Code/external/mariadb-columnstore-api
+mkdir dotnet/lib-linux-x64
+mkdir build-linux-x64
+cd build-linux-x64
+cmake ..
+make
+cp src/libmcsapi.* ../dotnet/lib-linux-x64
+```
+
+### Build the NuGet Package
+
+Now from either gitbash (Windows) or a WSL prompt, where ever you have the dotnet core SDK
+installed, you can generate a NuGet package.
+
+```shell
+cd dotnet/src
+dotnet pack -c Release
+```
+
+This NuGet package is self contained with the needed platform specific glue libraries, and
+the needed DLLs for windows. That is, when using this package under windows, one does not
+need to install mcsapi.so and the support libraries separately.
+
+### Testing
+
+Currently the tests are very basic and rely on the t1 table existing in the mcsapi database.
+The easiest way to perform the tests is to run the MariaDB ColumnStore in the WSL instance, make
+the mcsapi database and t1 table, and then run ```dotnet test```. If you copy over the
+WSL Columnstore.xml file to e.g. /c/opt/mariadb/etc, then you can also run the tests from windows.
+
+### Testing on Windows
+
+To run the tests in dotnet/test in windows, one will need to set some environment variables, which are
+mostly the same as outlined in the main README for windows testing:
+
+* ```COLUMNSTORE_INSTALL_DIR``` -- Required for windows, points to the folder holding the etc/Columnstore.xml file.
+* ```PATH``` -- This environment variable must also contain the dotnet/lib-win-x64 directory (as an absolute path).
+  Windows uses this to find the DLLs to use for testing.
+
+## END OF LINE
+
+[//]: # (cSpell:ignore cmake gitbash mkdir libxml libuv libiconv mcsapi mcsmysql mariadb columnstore libmcsapi nuget .)

--- a/dotnet/build.sh
+++ b/dotnet/build.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+#
+# bash / (git)bash script to build a nuget package.
+#
+# Uses modern bash features such as arrays.
+#
+# Also this script plays well with build-win-x64.sh
+#  (https://gist.github.com/TikiBill/3dc83d90e5337eb168da82c207f077e3)
+
+
+#Make sure we are working in our source directory.
+cd $(dirname $BASH_SOURCE)
+
+WARNINGS=()
+
+if [ -z "$SWIG_EXECUTABLE" ]; then
+    SWIG_EXECUTABLE=$(which swig 2>/dev/null)
+fi
+
+if [ -z "$PKG_CONFIG" ]; then
+    PKG_CONFIG=$(which pkg-config 2>/dev/null)
+fi
+
+let MISSING=0
+MISSING_DLLS=""    
+
+if [ -z "$PROGRAMFILES" ]; then
+    TARGET="linux-x64"
+    BUILD_DIR="build-$TARGET"
+    OUTPUT_DLL="glue-lib/dotnet_mcsapi.so"
+    DEST_LIB_DIR="lib-$TARGET"
+
+    # Assuming the README was followed.
+    API_DLL_DIR="../build-linux-x64/src"    
+    REQUIRED_DLLS="libmcsapi.so libmcsapi.a"
+
+    if [ ! -d "$DEST_LIB_DIR" ]; then
+        if ! mkdir "$DEST_LIB_DIR"; then echo "FAILED to mkdir $DEST_LIB_DIR"; exit 1; fi
+    fi
+
+else
+    # Windows Config
+    TARGET="win-x64"
+    BUILD_DIR="build-$TARGET"
+    BUILD_CONFIG="RelWithDebInfo"
+    OUTPUT_DLL="glue-lib/$BUILD_CONFIG/dotnet_mcsapi.dll"
+    DEST_LIB_DIR="lib-$TARGET"
+
+    #Assuming the build-win-x64 script was used:
+    API_DLL_DIR="../build-win-x64/src/RelWithDebInfo"
+
+    REQUIRED_DLLS="mcsapi.dll mcsapi.lib libiconv.dll libuv.dll libxml2.dll"
+fi
+
+if [ ! -d "$DEST_LIB_DIR" ]; then
+    if ! mkdir "$DEST_LIB_DIR"; then echo "FAILED to mkdir $DEST_LIB_DIR"; exit 1; fi
+fi
+
+for DLL in $REQUIRED_DLLS; do
+    if [ ! -e "./$DEST_LIB_DIR/$DLL" ]; then
+        if [ ! -z "$MCSAPI_BUILD_DEPENDENCY_DIR" -a -e "$MCSAPI_BUILD_DEPENDENCY_DIR/lib/$DLL" ]; then
+            echo "NOTE: Missing ./$DEST_LIB_DIR/$DLL but found it in $MCSAPI_BUILD_DEPENDENCY_DIR/lib"
+            if cp -v "$MCSAPI_BUILD_DEPENDENCY_DIR/lib/$DLL" "./$DEST_LIB_DIR/$DLL"; then
+                WARNINGS+=("Copied $MCSAPI_BUILD_DEPENDENCY_DIR/lib/$DLL  -->  ./$DEST_LIB_DIR/$DLL")
+            else
+                echo "ERROR Copy failed!"
+                exit 1
+            fi
+            echo
+        elif [ -e "$API_DLL_DIR/$DLL" ]; then
+            echo "NOTE: Missing ./$DEST_LIB_DIR/$DLL but found it in $API_DLL_DIR"
+            if cp -v "$API_DLL_DIR/$DLL" "./$DEST_LIB_DIR/$DLL"; then
+                WARNINGS+=("Copied $API_DLL_DIR/$DLL  -->  ./$DEST_LIB_DIR/$DLL")
+            else
+                echo "ERROR Copy failed!"
+                exit 1
+            fi
+            echo
+        else
+            MISSING=$((MISSING+1))
+            echo "ERROR: Missing ./$DEST_LIB_DIR/$DLL"
+            MISSING_DLLS="$MISSING_DLLS ./$DEST_LIB_DIR/$DLL"
+        fi
+    elif [ -e "$API_DLL_DIR/$DLL" -a "$API_DLL_DIR/$DLL" -nt "./$DEST_LIB_DIR/$DLL" ]; then
+        WARNINGS+=("WARNING: $API_DLL_DIR/$DLL is newer than ./$DEST_LIB_DIR/$DLL")
+        echo "${WARNINGS[-1]}"
+    fi
+done
+
+if [ $MISSING -gt 0 ]; then
+    echo
+    echo "ERROR: Missing some required DLLs:$MISSING_DLLS"
+    echo
+    echo "  The DLLs are needed for packing a complete NuGet package (and testing)."
+    exit 1
+fi
+
+#Compare versions in a crude way.
+VERSION_MAJOR=$(cat ../cmake/version.cmake |grep -E 'set\( *VERSION_MAJOR *[0-9]+ *\)' | sed -r 's/.*(VERSION_MAJOR +([0-9]+)).*/\2/')
+VERSION_MINOR=$(cat ../cmake/version.cmake |grep -E 'set\( *VERSION_MINOR *[0-9]+ *\)' | sed -r 's/.*(VERSION_MINOR +([0-9]+)).*/\2/')
+VERSION_PATCH=$(cat ../cmake/version.cmake |grep -E 'set\( *VERSION_PATCH *[0-9]+ *\)' | sed -r 's/.*(VERSION_PATCH +([0-9]+)).*/\2/')
+API_VERSION="$VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH"
+NUGET_VERSION=$(cat ./src/ColumnStoreDotNet.csproj | grep -E '<PackageVersion>' | sed -r 's/.*<PackageVersion> *([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+
+if [ "$API_VERSION" != "$NUGET_VERSION" ]; then
+    WARNINGS+=("WARNING: API Version ($API_VERSION) Does Not Match NuGet Version ($NUGET_VERSION) -- Perhaps edit ColumnStoreDotNet.csproj?")
+    echo "${WARNINGS[-1]}"
+fi
+
+OUTPUT_DLL_ABS=`pwd`"/$OUTPUT_DLL"
+
+if [ -z "$SWIG_EXECUTABLE" ]; then
+    echo "ERROR: swig executable not found/known."
+    echo "  Please add swig to your path or set"
+    echo "  the SWIG_EXECUTABLE environment variable."
+    echo "  to point to the executable."
+    exit 1
+fi
+
+if [ -z "$PKG_CONFIG" ]; then
+    echo "ERROR: pkg-config executable not found/known."
+    echo "  Please add pkg-config to your path or set"
+    echo "  the PKG_CONFIG environment variable to point"
+    echo "  to the executable."
+    exit 1
+fi
+
+
+if [ -e "CMakeCache.txt" ]; then
+    echo "ERROR: You have a CMakeCache.txt in the main dotnet directory!"
+    echo "  This will result in a conflict and incorrect builds."
+    echo "  Please clean up your previous cmake."
+    exit 1
+fi
+
+if [ ! -d "$BUILD_DIR" ]; then
+    if ! mkdir -p "$BUILD_DIR"; then echo "FAILED to mkdir $BUILD_DIR"; exit 1; fi
+fi
+
+if ! cd "$BUILD_DIR"; then echo "FAILED to cd $BUILD_DIR"; exit 1; fi
+
+if [ "$TARGET" = "win-x64" ]; then
+    SETUP_CMD="cmake -G \"Visual Studio 15 2017 Win64\" .. -DSWIG_EXECUTABLE:PATH=\"$SWIG_EXECUTABLE\""
+    BUILD_CMD="cmake --build . --config \"$BUILD_CONFIG\""
+elif [ "$TARGET" = "linux-x64" ]; then
+    SETUP_CMD='cmake ..'
+    BUILD_CMD="make"
+else
+    echo "ERROR: Unknown target '$TARGET'"
+    exit 1
+fi
+
+echo
+echo
+echo "* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *"
+echo "    $TARGET    PWD: " $(pwd)
+echo "    RUNNING: $SETUP_CMD"
+echo
+
+if ! eval "$SETUP_CMD"; then
+    echo "ERROR: Command Failed!"
+    echo "Tried to run: $SETUP_CMD"
+    exit 1
+fi
+
+
+echo
+echo
+echo "* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *"
+echo "    $TARGET    PWD: " $(pwd)
+echo "    RUNNING: $BUILD_CMD"
+echo
+
+if ! eval "$BUILD_CMD"; then
+    echo "ERROR: Command Failed!"
+    echo "Tried to run: $BUILD_CMD"
+    exit 1
+fi
+
+if [ -e "$OUTPUT_DLL" ]; then
+    CP_CMD="cp -v \"$OUTPUT_DLL\" \"../$DEST_LIB_DIR/\""
+    echo -n "COPY: $CP_CMD    --->    "    
+    if ! eval $CP_CMD; then "FAILED to $CP_CMD"; exit 1; fi
+else
+    echo "Hrm, DLL Not Produced? Looked for $OUTPUT_DLL"
+    CP_CMD="(No Copy Done)"
+fi
+
+
+echo
+echo
+echo "* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *"
+echo "        MariaDB ColumnStore API Version: $API_VERSION"
+echo "  NuGet Package Version (without build): $NUGET_VERSION"
+echo
+echo "Sucssfully setup/built with commands:"
+echo "  $SETUP_CMD"
+echo "  $BUILD_CMD"
+echo "  $CP_CMD"
+echo
+
+if [ ${#WARNINGS[@]} -gt 0 ]; then
+    echo "*** NOTICE ***"
+    for WARN in "${WARNINGS[@]}"; do
+        echo "$WARN"
+    done
+    echo
+fi

--- a/dotnet/clean.sh
+++ b/dotnet/clean.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Clean the dotnet directory from build and cmake files.
+
+#Make sure we are working in our source directory.
+cd $(dirname $BASH_SOURCE)
+
+rm -rfv build-linux build-win64 *.vcxproj* \
+    CMakeCache.txt CMakeFiles cmake_install.cmake \
+    dotnet_mcsapi_wrap.cxx Project.sln Makefile \
+    Debug Win32 \
+    lib-win64/dotnet_mcsapi.* \
+    lib-linux/dotnet*.so \
+    src/obj src/bin src/*.cs \
+    test/obj test/bin test/*.log \
+    example/obj example/bin

--- a/dotnet/dotnet_mcsapi.i
+++ b/dotnet/dotnet_mcsapi.i
@@ -1,0 +1,58 @@
+/* Copyright (c) 2017, MariaDB Corporation. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+
+%module dotnet_mcsapi
+
+// Get proper PascalCaseIdentifiers
+%rename("%(ctitle)s") "";
+
+%include exception.i
+
+// http://www.swig.org/Doc3.0/CSharp.html#CSharp_exceptions
+%exception {
+  try {
+    $action
+  } catch (mcsapi::ColumnStoreError &e) {
+    SWIG_CSharpSetPendingException(SWIG_CSharpApplicationException, e.what());
+    return $null;
+  } catch (std::bad_alloc &er) {
+    SWIG_exception(SWIG_RuntimeError,const_cast<char*>(er.what()));
+  }  
+}
+
+%{
+#include "libmcsapi/mcsapi.h"
+%}
+
+/* MCOL-1321 */
+%include "typemaps.i"
+%apply int *OUTPUT { mcsapi::columnstore_data_convert_status_t* status };
+/* MCOL-1321 */
+
+/* swig includes for standard types / exceptions */
+%include <std_except.i>
+%include <std_string.i>
+%include <stdint.i>
+
+/* include each of the mcsapi.h files and dependencies directly for swig to process */
+%include "libmcsapi/visibility.h"
+%include "libmcsapi/mcsapi_types.h"
+%include "libmcsapi/mcsapi_exception.h"
+%include "libmcsapi/mcsapi_driver.h"
+%include "libmcsapi/mcsapi_bulk.h"
+

--- a/dotnet/example/CpImport.cs
+++ b/dotnet/example/CpImport.cs
@@ -1,0 +1,223 @@
+
+
+using System;
+using Microsoft.Extensions.Logging;
+using CsvHelper;
+using System.IO;
+using System.Diagnostics;
+
+namespace MariaDB.Data.ColumnStore
+{
+    public class CpImport
+    {
+        private ILogger _logger;
+        public ColumnStoreDriver McsDriver { get; private set; }
+        public string ColumnStoreXmlFilepath { get; private set; }
+        public string DbName { get; set; }
+        public string TableName { get; set; }
+
+        /// <summary>
+        /// The number of lines to ignore before processing the data.
+        /// </summary>
+        public int HeaderLines { get; set; } = 1;
+
+        public CpImport(ILogger logger)
+        {
+            this._logger = logger;
+            this._logger?.LogInformation("New CpImport w/o a specific XML file.");
+        }
+
+        /// <summary>
+        /// New CpImport object with a logger and config file specified.
+        /// </summary>
+        /// <param name="logger">Logger for messages, or set to null.</param>
+        /// <param name="columnStoreXmlFilepath">The full path and filename to the Colmunstore.xml file.</param>
+        public CpImport(ILogger logger, string columnStoreXmlFilepath)
+        {
+            this._logger = logger;
+            this.ColumnStoreXmlFilepath = columnStoreXmlFilepath;
+            if (string.IsNullOrWhiteSpace(this.ColumnStoreXmlFilepath))
+            {
+                this._logger?.LogInformation("New CpImport w/o a specific XML file.");
+            }
+            else
+            {
+                this._logger?.LogInformation("New CpImport w/Columnstore.xml = " + this.ColumnStoreXmlFilepath);
+            }
+        }
+
+
+        public bool TryGetDriver()
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(this.ColumnStoreXmlFilepath))
+                {
+                    this.McsDriver = new ColumnStoreDriver();
+                }
+                else
+                {
+                    this.McsDriver = new ColumnStoreDriver(this.ColumnStoreXmlFilepath);
+                }
+            }
+            catch (Exception e)
+            {
+                this._logger?.LogError("Failed to setup ColumnStoreDriver: " + e.Message);
+                if (string.IsNullOrWhiteSpace(this.ColumnStoreXmlFilepath))
+                {
+                    this._logger?.LogError("(Perhaps specify the ColumnStore.xml full path?");
+                }
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Try to connect to the ColumnStore database through the API.
+        /// Useful for checking the configuration is valid
+        /// before attempting an import.
+        /// </summary>
+        /// <returns>Returns true if a connection could be made.</returns>
+        public bool TryConnect()
+        {
+            if (string.IsNullOrWhiteSpace(this.DbName))
+            {
+                this._logger?.LogError("No DbName Set! (Therefore cannot connect.)");
+                return false;
+            }
+            else if (string.IsNullOrWhiteSpace(this.TableName))
+            {
+                this._logger?.LogError("No TableName Set! (Therefore cannot connect.)");
+            }
+            else
+            {
+                ColumnStoreBulkInsert bulkInsert = null;
+                try
+                {
+                    bulkInsert = this.McsDriver.CreateBulkInsert(this.DbName, this.TableName, 0, 0);
+                    this._logger?.LogInformation("Connected to " + this.TableName + " in " + this.DbName);
+                }
+                catch (Exception e)
+                {
+                    this._logger?.LogError("Could not connect: " + e.Message);
+                    return false;
+                }
+                finally
+                {
+                    // Otherwise this check will hang.
+                    if (!(bulkInsert is null))
+                    {
+                        bulkInsert.Rollback();
+                        bulkInsert = null;
+                    }
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Load all *.csv files in a directory.
+        /// </summary>
+        public void ImportCsvFilesInDirectory(string directoryName)
+        {
+            foreach (var file in Directory.GetFiles(directoryName, "*.csv"))
+            {
+                // Note that file contains a full path.
+                this.ImportCsv(file);
+            }
+        }
+
+
+        /// <summary>
+        /// Load a single file.
+        /// </summary>
+        public void ImportCsv(string fileName)
+        {
+            using (var streamReader = File.OpenText(fileName))
+            {
+                this.ImportCsv(streamReader);
+            }
+        }
+
+
+        /// <summary>
+        /// Load CSV data from a TextReader.
+        /// 
+        /// This performs the entire commit in a single transaction after
+        /// reading the entire file.
+        /// </summary>
+        public void ImportCsv(TextReader textReader)
+        {
+            // https://joshclose.github.io/CsvHelper/reading#getting-all-records
+            var csv = new CsvReader(textReader);
+            csv.Configuration.MissingFieldFound = null; // Don't throw when missing.
+
+            for (int i = 0; i < this.HeaderLines; i++)
+            {
+                csv.Read();
+                csv.ReadHeader();
+            }
+
+            var systemCatalog = this.McsDriver.GetSystemCatalog();
+            var tableInfo = systemCatalog.GetTable(this.DbName, this.TableName);
+
+            // Avoid a method call in the loop.
+            ushort tableColumnCount = tableInfo.GetColumnCount();
+
+
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            ColumnStoreBulkInsert bulkInsert = null;
+            try
+            {
+                bulkInsert = this.McsDriver.CreateBulkInsert(this.DbName, this.TableName, 0, 0);
+
+                int count = 0;
+                while (csv.Read())
+                {
+                    count += 1;
+                    if (count % 1000 == 0)
+                    {
+                        this._logger?.LogInformation("{0} Rows in {1} seconds.", count, stopwatch.Elapsed);
+                    }
+
+                    // Note the use of ushort here.
+                    for (ushort i = 0; i < tableColumnCount; i++)
+                    {
+                        // The API does not like nulls, so null-collesse to the empty string.
+                        bulkInsert.SetColumn(i, csv.GetField(i) ?? string.Empty);
+                    }
+                    bulkInsert.WriteRow();
+                }
+            }
+            catch (Exception ex)
+            {
+                this._logger?.LogError("Exception Thrown: " + ex.Message);
+
+                if (!(bulkInsert is null))
+                {
+                    bulkInsert.Rollback();
+                    bulkInsert = null;
+                }
+
+                throw; // And re-throw the exception
+            }
+
+            stopwatch.Stop();
+            this._logger?.LogInformation("Total Time: {0}", stopwatch.Elapsed);
+
+            if (!(bulkInsert is null))
+            {
+                bulkInsert.Commit();
+                // print a short summary of the insertion process
+                ColumnStoreSummary summary = bulkInsert.GetSummary();
+                this._logger?.LogInformation("Execution time: " + summary.GetExecutionTime());
+                this._logger?.LogInformation("Rows inserted: " + summary.GetRowsInsertedCount());
+                this._logger?.LogInformation("Truncation count: " + summary.GetTruncationCount());
+                this._logger?.LogInformation("Saturated count: " + summary.GetSaturatedCount());
+                this._logger?.LogInformation("Invalid count: " + summary.GetInvalidCount());
+            }
+        }
+    }
+}

--- a/dotnet/example/CpImport.csproj
+++ b/dotnet/example/CpImport.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandlineParser" Version="2.3.65" />
+    <PackageReference Include="CsvHelper" Version="12.0.1" />
+    <PackageReference Include="MariaDB.Data.ColumnStoreDriver" Version="1.1.6.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/example/Program.cs
+++ b/dotnet/example/Program.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.IO;
+using CommandLine;
+using Microsoft.Extensions.Logging;
+using MariaDB.Data.ColumnStore;
+
+namespace MariaDB.Data.ColumnStore.ExampleLoader
+{
+    class Options
+    {
+        [Option('f', "file", HelpText = "The CSV file, a directory containing CSV files.")]
+        public string DataDirectory { get; set; }
+
+        [Option("header-lines", HelpText = "The number of lines to ignore in the csv file. Defaults to 1")]
+        public int HeaderLines { get; set; } = -1; // Strange default so we can detect when it is set to zero.
+
+        [Option('c', "config", HelpText = "Path to the Columnstore.xml file, e.g. /opt/mariadb/etc/Columnstore.xml")]
+        public string ColumnStoreXmlFilePath { get; set; }
+
+        [Option('d', "db", HelpText = "Database name.")]
+        public string DbName { get; set; }
+
+        [Option('t', "table", HelpText = "Table name to load.")]
+        public string TableName { get; set; }
+    }
+
+    class Program
+    {
+        public static ColumnStoreDriver mcsDriver;
+        public static ILoggerFactory loggerFactory;
+        public static ILogger logger;
+
+        static void Main(string[] args)
+        {
+            loggerFactory = new LoggerFactory().AddConsole();
+            logger = loggerFactory.CreateLogger<Program>();
+
+            Parser.Default.Settings.MaximumDisplayWidth = 132; // For help formatting.
+
+            try
+            {
+                var result = Parser.Default.ParseArguments<Options>(args)
+                    .WithParsed<Options>(opts => ProcessOptions(opts));
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("* * *  EXCEPTION: " + ex.Message + "   * * *");
+                Console.WriteLine(string.Empty);
+                Console.WriteLine(ex.StackTrace);
+            }
+        }
+
+        /// <summary>
+        /// Process the options (and run the program).
+        /// 
+        /// This method tries to connect to the database before
+        /// checking other options so that one can verify they can
+        /// connect to a database via the API without having to get
+        /// all the other options correct.
+        /// </summary>
+        public static void ProcessOptions(Options options)
+        {
+            var cpImport = new CpImport(
+                    loggerFactory.CreateLogger<CpImport>(),
+                    options.ColumnStoreXmlFilePath
+                );
+
+            // These could be null, but we check below.
+            cpImport.DbName = options.DbName;
+            cpImport.TableName = options.TableName;
+
+            if (options.HeaderLines >= 0)
+            {
+                cpImport.HeaderLines = options.HeaderLines;
+            }
+
+            if (!cpImport.TryGetDriver())
+            {
+                Console.Error.WriteLine("Could not create a ColumnStoreDriver!");
+                Console.Error.WriteLine("(Perhaps try --config /path/to/Columnstore.xml ?)");
+                return;
+            }
+            else if (string.IsNullOrWhiteSpace(options.DbName))
+            {
+                Console.Error.WriteLine("Need a --db DATABASE");
+                return;
+            }
+            else if (string.IsNullOrWhiteSpace(options.TableName))
+            {
+                Console.Error.WriteLine("Need a --table TABLE");
+                return;
+            }
+            else if (!cpImport.TryConnect())
+            {
+                Console.Error.WriteLine(
+                        "Failed to make a test connection to "
+                        + cpImport.TableName
+                        + " in "
+                        + cpImport.DbName
+                    );
+                return;
+            }
+            else if (string.IsNullOrWhiteSpace(options.DataDirectory))
+            {
+                Console.Error.WriteLine("Need a --file file.csv");
+            }
+            else if (File.Exists(options.DataDirectory))
+            {
+                cpImport.ImportCsv(options.DataDirectory);
+            }
+            else if (Directory.Exists(options.DataDirectory))
+            {
+                cpImport.ImportCsvFilesInDirectory(options.DataDirectory);
+            }
+            else
+            {
+                // Did not exist at all.
+                Console.Error.WriteLine("ERROR: {0} does not exist.", options.DataDirectory);
+            }
+        }
+    }
+}

--- a/dotnet/example/README.md
+++ b/dotnet/example/README.md
@@ -1,0 +1,14 @@
+# Getting Started with c# and .NET Core
+
+This is a data loader inspired by
+[MariaDB Analytics Tutorial: 5 Steps to Get Started in 10 Minutes](https://mariadb.com/resources/blog/mariadb-analytics-tutorial-5-steps-to-get-started-in-10-minutes/)
+and also
+<https://github.com/mariadb-corporation/mariadb-columnstore-api/tree/master/example/CpImport>
+
+## Example
+
+From a git-bash command line:
+
+```shell
+ dotnet run -- --config /c/opt/mariadb/etc/Columnstore.xml --db loans --table loanstats --file ~/data/LoanStats3a.csv --header-lines 2
+ ```

--- a/dotnet/src/ColumnStoreDotNet.csproj
+++ b/dotnet/src/ColumnStoreDotNet.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageId>MariaDB.Data.ColumnStoreDriver</PackageId>
+    <PackageVersion>1.1.6.1</PackageVersion>
+    <Authors>Bill Adams</Authors>
+    <PackageProjectUrl>https://github.com/mariadb-corporation/mariadb-columnstore-api</PackageProjectUrl>
+    <Description>MariaDB ColumnStore API for .Net Core (by wrapping the c++ API).
+
+    This NuGet pacakage currently supports linux-x64 and win-x64.
+
+    The NuGet major.minor.patch version reflects the c++ version number and then
+    a build number is added to that.
+    </Description>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageReleaseNotes>
+      1.1.6.1
+        - First release.
+    </PackageReleaseNotes>
+    <Copyright>Copyright 2018</Copyright>
+    <PackageTags>Client MariaDB ColumnStore</PackageTags>
+							       
+  </PropertyGroup>
+
+    <Target Name="SharedLibTarget" AfterTargets="Build">
+      <Copy SourceFiles="@(MyPackageFiles)" DestinationFolder="$(OutputPath)" ContinueOnError="false" />
+    </Target>
+
+      <ItemGroup>
+        <None Include="..\lib-win-x64\*.dll" Pack="true" PackagePath="runtimes\win-x64\native" />
+        <None Include="..\lib-linux-x64\*.so" Pack="true" PackagePath="runtimes\linux-x64\native" />
+      </ItemGroup>
+
+</Project>
+

--- a/dotnet/test/ColumnStoreDotNetTest.csproj
+++ b/dotnet/test/ColumnStoreDotNetTest.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <ProjectReference Include="..\src\ColumnStoreDotNet.csproj" />
+  </ItemGroup>
+  
+  <Target Name="TestTarget" AfterTargets="Build">
+	  <Copy SourceFiles="..\lib-linux\dotnet_mcsapi.so" DestinationFolder="$(OutputPath)" ContinueOnError="false" Condition=" '$(OS)' == 'Unix' " />
+  </Target>
+
+</Project>

--- a/dotnet/test/ColumnStoreDriverTest.cs
+++ b/dotnet/test/ColumnStoreDriverTest.cs
@@ -1,0 +1,294 @@
+using System;
+using System.IO;
+using Xunit;
+using MariaDB.Data.ColumnStore;
+
+// cSpell:ignore xunit mariadb mcsapi libuv libiconv
+
+namespace test
+{
+    public class ColumnStoreDriverTest
+    {
+        // https://stackoverflow.com/questions/5116977/how-to-check-the-os-version-at-runtime-e-g-windows-or-linux-without-using-a-con
+        public static bool IsLinux
+        {
+            get
+            {
+                int p = (int)Environment.OSVersion.Platform;
+                return (p == 4) || (p == 6) || (p == 128);
+            }
+        }
+
+
+
+        public static string[] ColumnstoreXmlPaths =
+            new string[]
+            {
+                "/etc",
+                "/usr/local/mariadb/columnstore/etc",
+            };
+
+        public static string TestDb = "mcsapi";
+        public static string TestTable = "t1";
+
+        public static string ColumnStoreXmlFilename = "Columnstore.xml";
+        public static string ColumnStoreInstallEnvVariable = "COLUMNSTORE_INSTALL_DIR";
+
+        /// <summary>
+        /// The path and filename found for the Columnstore.xml config.
+        /// </summary>
+        public static string ColumnstoreXmlFilePath = null;
+
+        public static bool FoundMcsapiDll = false;
+        public static bool FoundDotnetMcsapiDll = false;
+        public static bool FoundLibiconvDll = false;
+        public static bool FoundLibuvDll = false;
+        public static bool FoundLibxml2Dll = false;
+
+        static ColumnStoreDriverTest()
+        {
+            var columnstoreInstallDir = Environment.GetEnvironmentVariable(ColumnStoreInstallEnvVariable);
+            if (string.IsNullOrWhiteSpace(columnstoreInstallDir))
+            {
+                for (int i = 0; i < ColumnstoreXmlPaths.Length; i++)
+                {
+                    if (File.Exists(Path.Combine(ColumnstoreXmlPaths[i], ColumnStoreXmlFilename)))
+                    {
+
+                        ColumnstoreXmlFilePath = Path.Combine(ColumnstoreXmlPaths[i], ColumnStoreXmlFilename);
+                        break;
+                    }
+                }
+            }
+            else if (!Directory.Exists(columnstoreInstallDir))
+            {
+                throw new ArgumentException(
+                        "The path specified in the environment variable "
+                        + ColumnStoreInstallEnvVariable
+                        + " ("
+                        + columnstoreInstallDir
+                        + ") does not exist!"
+                        + " (Please be sure to specify an absolute path.)"
+                    );
+            }
+            else
+            {
+                ColumnstoreXmlFilePath = Path.Combine(columnstoreInstallDir, "etc", ColumnStoreXmlFilename);
+            }
+
+            if (string.IsNullOrWhiteSpace(ColumnstoreXmlFilePath))
+            {
+                throw new ArgumentException(
+                        "Did not find "
+                        + ColumnStoreXmlFilename
+                        + " Please set the environment variable "
+                        + ColumnStoreInstallEnvVariable
+                        + " to a directory containing this file."
+                    );
+            }
+            else if (!File.Exists(ColumnstoreXmlFilePath))
+            {
+                throw new ArgumentException(
+                        ColumnstoreXmlFilePath
+                        + " does not exist? Please check/set the environment variable "
+                        + ColumnStoreInstallEnvVariable
+                    );
+            }
+
+            if (IsLinux)
+            {
+
+            }
+            else
+            {
+                // Windows
+                if (!PathContainsWindowsDlls())
+                {
+                    throw new ArgumentException(
+                        "Did not find all of the needed DLLs in your PATH."
+                        + " SOURCE_DIR/dotnet/lib-win64 needs to be in the PATH"
+                        + " and contain:"
+                        + " dotnet_mcsapi.dll mcsapi.dll libiconv.dll libuv.dll libxml2.dll"
+                    );
+                }
+            }
+        }
+
+        // public static string GetExecutingDirectoryName()
+        // {
+        //     var location = new Uri(Assembly.GetEntryAssembly().GetName().CodeBase);
+        //     return new FileInfo(location.AbsolutePath).Directory.FullName;
+        // }
+
+
+        /// <summary>
+        /// Crude way to check for needed DLLs. For windows, the DLLs need to be
+        /// in the PATH. They cannot be in the same directory as the .NET DLLs as
+        /// the c++ DLLs are unmanaged and putting them in the .NET assembly directory
+        /// will produce hard-to-diagnose errors.
+        /// </summary>
+        public static bool PathContainsWindowsDlls()
+        {
+            var currentPaths = Environment.GetEnvironmentVariable("PATH").Split(Path.PathSeparator);
+            for (int i = 0; i < currentPaths.Length; i++)
+            {
+                if (currentPaths[i].EndsWith(@"\dotnet\lib-win64") || currentPaths[i].EndsWith("/dotnet/lib-win64"))
+                {
+
+                    foreach (string filePath in Directory.EnumerateFiles(currentPaths[i], "*.dll"))
+                    {
+                        switch (Path.GetFileName(filePath).ToLower())
+                        {
+                            case "dotnet_mcsapi.dll":
+                                FoundDotnetMcsapiDll = true;
+                                break;
+                            case "mcsapi.dll":
+                                FoundMcsapiDll = true;
+                                break;
+                            case "libiconv.dll":
+                                FoundLibiconvDll = true;
+                                break;
+                            case "libuv.dll":
+                                FoundLibuvDll = true;
+                                break;
+                            case "libxml2.dll":
+                                FoundLibxml2Dll = true;
+                                break;
+                        }
+                    }
+                }
+            }
+            return FoundDotnetMcsapiDll && FoundMcsapiDll
+                && FoundLibiconvDll && FoundLibuvDll && FoundLibxml2Dll;
+        }
+
+
+        /// <summary>
+        /// Very basic test. This just makes sure that we can load the
+        /// dlls/shared libraries by creating a new instance.
+        /// 
+        /// e.g., run:
+        /// 
+        ///  dotnet test --filter "FullyQualifiedName=test.ColumnStoreDriverTest.DllLoadTest"
+        /// 
+        /// To verify the setup is OK for runing further tests.
+        /// </summary>
+        [Fact]
+        public void DllLoadTest()
+        {
+            var d = new ColumnStoreDriver(ColumnstoreXmlFilePath);
+            Assert.NotNull(d);
+        }
+
+        /// <summary>
+        /// This test goes one step further by calling createBulkInsert, which
+        /// will use the information in Columntore.xml to connect to the node(s)
+        /// and check the DB + tables exist.
+        /// </summary>
+        [Fact]
+        public void ConnectTest()
+        {
+            var d = new ColumnStoreDriver(ColumnstoreXmlFilePath);
+            Assert.NotNull(d);
+            ColumnStoreBulkInsert b = null;
+            try
+            {
+                b = d.CreateBulkInsert(TestDb, TestTable, 0, 0);
+                Assert.NotNull(b);
+                b.Rollback(); // important, otherwise this will hang and throw.
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(string.Empty);
+                Console.WriteLine(ex.Message);
+                Console.WriteLine(ex.StackTrace);
+                Console.WriteLine(string.Empty);
+                if (ex.Message.Contains("not found"))
+                {
+                    Console.WriteLine("Please make sure the table " + TestTable
+                        + " exists in the " + TestDb + " datbase.");
+                    Console.WriteLine("Please create the 't1' table outlined in https://mariadb.com/kb/en/library/columnstore-bulk-write-sdk/");
+                }
+                else if (ex.Message.Contains("Table already locked"))
+                {
+                    Console.WriteLine("Try: sudo /usr/local/mariadb/columnstore/bin/dbrmctl resume");
+                }
+                Assert.True(false, "Could not connect/create a bulk insert instance.");
+            }
+            finally
+            {
+                if (!(b is null))
+                {
+                    b.Rollback();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Make sure that connecting to a non-existent db fails.
+        /// </summary>
+        [Fact]
+        public void FailConnectTest()
+        {
+            var d = new ColumnStoreDriver(ColumnstoreXmlFilePath);
+            Assert.NotNull(d);
+            ColumnStoreBulkInsert b = null;
+            try
+            {
+                b = d.CreateBulkInsert("db-does-not-exist", TestTable, 0, 0);
+                Assert.True(false, "Created a bulk insert instance against a non-existent db.");
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("not found"))
+                {
+                    Assert.True(true, "Could not connect/create a bulk insert instance against a non-existent db.");
+                }
+                else
+                {
+                    Assert.True(false, "Wrong exception returned? " + ex.Message);
+                }
+            }
+            finally
+            {
+                if (!(b is null))
+                {
+                    b.Rollback();
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Make sure the column catalog information is correct.
+        /// </summary>
+        [Fact]
+        public void ColumnCatalogTest()
+        {
+            var d = new ColumnStoreDriver(ColumnstoreXmlFilePath);
+            Assert.NotNull(d);
+            try
+            {
+                var tableInfo = d.GetSystemCatalog().GetTable(TestDb, TestTable);
+                Assert.NotNull(tableInfo);
+
+                // Note that the number in GetColumn is a ushort, so beware when
+                // looping with an int.
+                Assert.Equal("i", tableInfo.GetColumn(0).GetColumnName());
+                Assert.Equal(ColumnstoreDataTypesT.DATATYPEINT, tableInfo.GetColumn(0).GetType());
+
+                Assert.Equal("c", tableInfo.GetColumn(1).GetColumnName());
+                Assert.Equal(ColumnstoreDataTypesT.DATATYPECHAR, tableInfo.GetColumn(1).GetType());
+
+                // One can also get information by name.
+                Assert.Equal((ushort)0, tableInfo.GetColumn("i").GetPosition());
+                Assert.Equal(ColumnstoreDataTypesT.DATATYPEINT, tableInfo.GetColumn("i").GetType());
+
+            }
+            catch (Exception ex)
+            {
+                Assert.True(false, "Getting table information failed: " + ex.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request will add the ability to generate a .NET Core build and NuGet package using swig. The README.md describes how to build a NuGET package that will support both Windows and Linux. (I don't have access to Mac hardware to add a build for that as well.)

It also includes a c# implementation of CpImport as an example (based off of the Java code).

The build.sh script helps walk through the process.

Thank you.

--Bill