### PR TITLE
MCOL-3276 Fix byte align padding junk problem

### DIFF
--- a/src/util_commands.cpp
+++ b/src/util_commands.cpp
@@ -416,6 +416,7 @@ void ColumnStoreCommands::weBulkCommit(uint32_t pm, uint64_t uniqueId, uint32_t 
         *messageOut >> oid;
         *messageOut >> partNum;
         *messageOut >> segNum;
+        segNum &= 0x0000ffff; // Top 4 bytes can be junk due to byte alignment
         *messageOut >> hwm;
 
         // De-duplication if there are two extents for a segment in this commit


### PR DESCRIPTION
segNum is 16bit sent as 32bit due to struct byte alignment. In Ubuntu
16.04 there is junk in the top 4 bytes, so lets mask them out.