### PR TITLE
Mcol 3554 - use ports from Columnstore.xml - skip version check flag

### DIFF
--- a/src/mcsapi_driver.cpp
+++ b/src/mcsapi_driver.cpp
@@ -282,6 +282,17 @@ const char* ColumnStoreDriverImpl::getXMLNode(const char* parent, const char* no
     return NULL;
 }
 
+uint32_t ColumnStoreDriverImpl::getXMLNodeUint(const char* parent, const char* node)
+{
+    const char* xmlRtnString = getXMLNode(parent, node);
+    if (xmlRtnString == NULL){
+        return 0;
+    }
+    uint32_t rtn = strtoul(xmlRtnString, NULL, 10);
+
+    return rtn;
+}
+
 uint32_t ColumnStoreDriverImpl::getPMCount()
 {
     const char* pmStringCount = getXMLNode("PrimitiveServers", "Count");

--- a/src/mcsapi_driver_impl.h
+++ b/src/mcsapi_driver_impl.h
@@ -37,6 +37,7 @@ public:
 
     void loadXML();
     const char* getXMLNode(const char* parent, const char* node);
+    uint32_t getXMLNodeUint(const char* parent, const char* node);
     uint32_t getDBRootCount();
     uint32_t getPMCount();
     void getDBRootsForPM(uint32_t pm, std::vector<uint32_t>& dbRoots);

--- a/src/util_commands.cpp
+++ b/src/util_commands.cpp
@@ -317,7 +317,8 @@ ColumnStoreNetwork* ColumnStoreCommands::getBrmConnection()
 
     const char* hostname = driver->getXMLNode("DBRM_Controller", "IPAddr");
     std::string host = hostname;
-    brmConnection = new ColumnStoreNetwork(uv_loop, host, PORT_DBRMCONTROLLER);
+    uint32_t portDbrmcontroller = driver->getXMLNodeUint("DBRM_Controller", "Port");
+    brmConnection = new ColumnStoreNetwork(uv_loop, host, portDbrmcontroller);
     return brmConnection;
 }
 
@@ -335,7 +336,8 @@ ColumnStoreNetwork* ColumnStoreCommands::getWeConnection(uint32_t pm)
         snprintf(node_type, 32, "pm%u_WriteEngineServer", pm);
         const char* hostname = driver->getXMLNode(node_type, "IPAddr");
         std::string host = hostname;
-        connection = new ColumnStoreNetwork(uv_loop, host, PORT_WRITEENGINE);
+        uint32_t portWriteEngine = driver->getXMLNodeUint(node_type, "Port");
+        connection = new ColumnStoreNetwork(uv_loop, host, portWriteEngine);
         weConnections[pm] = connection;
     }
     return connection;
@@ -747,11 +749,13 @@ uint64_t ColumnStoreCommands::brmGetUniqueId()
 
 bool ColumnStoreCommands::procMonCheckVersion()
 {
+    // TODO, add a flag in Columnstore.xml that skips procMonCheckVersion for SkySQL
     ColumnStoreMessaging messageIn;
     ColumnStoreMessaging* messageOut;
     const char* hostname = driver->getXMLNode("pm1_ProcessMonitor", "IPAddr");
     std::string host = hostname;
-    ColumnStoreNetwork* connection = new ColumnStoreNetwork(uv_loop, host, PORT_PROCMON);
+    int32_t procMonPort = driver->getXMLNodeUint("pm1_ProcessMonitor", "Port");
+    ColumnStoreNetwork* connection = new ColumnStoreNetwork(uv_loop, host, procMonPort);
     miscConnections.push_back(connection);
     // Connect
     runSoloLoop(connection);

--- a/src/util_commands.cpp
+++ b/src/util_commands.cpp
@@ -749,7 +749,14 @@ uint64_t ColumnStoreCommands::brmGetUniqueId()
 
 bool ColumnStoreCommands::procMonCheckVersion()
 {
-    // TODO, add a flag in Columnstore.xml that skips procMonCheckVersion for SkySQL
+    // Skip the version check on SkySQL clients that have the SkipVersionCheck flag set to "Y" or "1"
+    const char* skipVersionCheck = driver->getXMLNode("SkySQL", "SkipVersionCheck");
+    if (skipVersionCheck != NULL){
+        std::string skipParameter = skipVersionCheck;
+        if (skipParameter.compare("Y") || skipParameter.compare("1")){
+            return true;
+        }
+    }
     ColumnStoreMessaging messageIn;
     ColumnStoreMessaging* messageOut;
     const char* hostname = driver->getXMLNode("pm1_ProcessMonitor", "IPAddr");

--- a/src/util_network.cpp
+++ b/src/util_network.cpp
@@ -33,7 +33,7 @@
 namespace mcsapi
 {
 ColumnStoreNetwork::ColumnStoreNetwork(uv_loop_t* loop,
-        std::string& host, columnstore_ports_t port):
+        std::string& host, uint32_t port):
             uv_loop(loop),
             buf(nullptr),
             con_status(CON_STATUS_NONE),

--- a/src/util_network.h
+++ b/src/util_network.h
@@ -21,16 +21,6 @@
 namespace mcsapi
 {
 
-enum columnstore_ports_t
-{
-    PORT_EXEMGR = 8601,
-    PORT_PRIMPROC = 8620,
-    PORT_WRITEENGINE = 8630,
-    PORT_DBRMCONTROLLER = 8616,
-    PORT_DBRMWORKER = 8700,
-    PORT_PROCMON = 8800
-};
-
 enum columnstore_con_status_t
 {
     CON_STATUS_NONE,
@@ -46,7 +36,7 @@ enum columnstore_con_status_t
 class ColumnStoreNetwork
 {
 public:
-    ColumnStoreNetwork(uv_loop_t* loop, std::string& host, columnstore_ports_t port);
+    ColumnStoreNetwork(uv_loop_t* loop, std::string& host, uint32_t port);
 
     columnstore_con_status_t getStatus() { return con_status; };
     void sendData(ColumnStoreMessaging& message);


### PR DESCRIPTION
- mcsapi uses the ports as defined in Columnstore.xml
- added an optional client side Columnstore.xml flag `<SkySQL>SkipVersionCheck>Y</SkipVersionCheck></SkySQL>` to skip the ProcMon version check
- (py|java)mcsapi test suite successfully executed against ColumnStore 1.2.2 on Debian 9
- manual pymcsapi connection test with minimal Columnstore.xml (SkipVersionCheck flag and no ProcMon entry) successful on Debian 9